### PR TITLE
[Feat] 관리자 디자인 카드 컴포넌트

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,7 @@ const preview: Preview = {
       },
     },
   },
+  tags: ['autodocs'],
 };
 
 export default preview;

--- a/src/components/common/Card/DesignCard.stories.ts
+++ b/src/components/common/Card/DesignCard.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import DesignCard from './DesignCard';
+
+const meta = {
+  title: 'Card/DesignCard',
+  component: DesignCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  args: { onContextMenu: fn() },
+} satisfies Meta<typeof DesignCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const normal: Story = {
+  args: {
+    title: '디자인 이름',
+    edit: '최근에 수정됨',
+    state: 'normal',
+  },
+};
+
+export const active: Story = {
+  args: {
+    title: '선택된 디자인 이름',
+    edit: '최근에 수정됨',
+    state: 'active',
+  },
+};

--- a/src/components/common/Card/DesignCard.stories.ts
+++ b/src/components/common/Card/DesignCard.stories.ts
@@ -3,12 +3,11 @@ import { fn } from '@storybook/test';
 import DesignCard from './DesignCard';
 
 const meta = {
-  title: 'Card/DesignCard',
+  title: 'common/DesignCard',
   component: DesignCard,
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   args: { onContextMenu: fn() },
 } satisfies Meta<typeof DesignCard>;
 

--- a/src/components/common/Card/DesignCard.tsx
+++ b/src/components/common/Card/DesignCard.tsx
@@ -1,11 +1,4 @@
-import { MouseEvent } from 'react';
-type Props = {
-  title?: string;
-  edit?: string;
-  image?: string;
-  state?: 'normal' | 'active';
-  onContextMenu?: (e: MouseEvent<HTMLDivElement>) => void;
-};
+import { DesignCardProps } from './DesignCard.types';
 
 export default function DesignCard({
   title = '디자인 이름이름',
@@ -13,7 +6,7 @@ export default function DesignCard({
   image,
   state = 'normal',
   onContextMenu,
-}: Props) {
+}: DesignCardProps) {
   const className = {
     getState: () => {
       switch (state) {
@@ -34,9 +27,9 @@ export default function DesignCard({
       onContextMenu={onContextMenu}
     >
       <div className="bg-d10 w-full h-full border flex justify-center items-center">
-        <img src={image} alt="designCardImage" />
+        <img src={image} alt="design preview" />
       </div>
-      <div className={`${className.getState()[1]}`}>
+      <div className={className.getState()[1]}>
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-base">{edit}</p>
       </div>

--- a/src/components/common/Card/DesignCard.tsx
+++ b/src/components/common/Card/DesignCard.tsx
@@ -1,0 +1,45 @@
+import { MouseEvent } from 'react';
+type Props = {
+  title?: string;
+  edit?: string;
+  image?: string;
+  state?: 'normal' | 'active';
+  onContextMenu?: (e: MouseEvent<HTMLDivElement>) => void;
+};
+
+export default function DesignCard({
+  title = '디자인 이름이름',
+  edit = '최근에 수정됨',
+  image,
+  state = 'normal',
+  onContextMenu,
+}: Props) {
+  const className = {
+    getState: () => {
+      switch (state) {
+        case 'normal':
+          return ['border-d900 bg-d10 hover:border-d700 hover:bg-d30', 'text-d700 hover:text-d700'];
+        case 'active':
+          return ['border-d900 bg-d900 hover:border-d700 hover:bg-d700', 'text-d10 hover:text-d10'];
+        default:
+          return ['', ''];
+      }
+    },
+  };
+
+  return (
+    <div
+      className={`flex flex-col w-[320px] h-[280px] p-4 gap-4 
+    ${className.getState()[0]} border rounded-lg`}
+      onContextMenu={onContextMenu}
+    >
+      <div className="bg-d10 w-full h-full border flex justify-center items-center">
+        <img src={image} alt="designCardImage" />
+      </div>
+      <div className={`${className.getState()[1]}`}>
+        <p className="text-2xl font-bold">{title}</p>
+        <p className="text-base">{edit}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Card/DesignCard.types.ts
+++ b/src/components/common/Card/DesignCard.types.ts
@@ -1,0 +1,9 @@
+import { MouseEvent } from 'react';
+
+export type DesignCardProps = {
+  title: string;
+  edit: string;
+  image?: string;
+  state: 'normal' | 'active';
+  onContextMenu: (e: MouseEvent<HTMLDivElement>) => void;
+};


### PR DESCRIPTION
### 작업 개요

- 관리자 레이아웃 컴포넌트 구성
  - `/Card/DesignCard`

### 반영 브랜치

ex) feat_common-component_design-card-> dev

### 연관된 이슈(optional)

- #5 

### 변경 사항(optional)

- `tailwind.config.js`: theme.colors d700 값 수정

### 스크린샷(optional)

- **DesignCard Storybook**
![image](https://github.com/user-attachments/assets/bb3bffc1-fea6-4f63-9168-b554ad20cb82)