### PR TITLE
[Feat] 관리자 우클릭 옵션 컴포넌트

### DIFF
--- a/src/components/common/Options/ContextOptions.stories.ts
+++ b/src/components/common/Options/ContextOptions.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import ContextOptions from './ContextOptions';
+
+const meta = {
+  title: 'common/ContextOptions',
+  component: ContextOptions,
+  parameters: {
+    layout: 'centered',
+  },
+  args: { onClick: fn() },
+} satisfies Meta<typeof ContextOptions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    options: [
+      { id: 1, name: '적용하기' },
+      { id: 2, name: '수정하기' },
+      { id: 3, name: '삭제하기' },
+    ],
+  },
+};

--- a/src/components/common/Options/ContextOptions.tsx
+++ b/src/components/common/Options/ContextOptions.tsx
@@ -1,0 +1,34 @@
+import { ContextOptionsProps } from './ContextOptions.types';
+
+export default function ContextOptions({
+  options = [
+    { id: 1, name: '적용하기' },
+    { id: 2, name: '수정하기' },
+    { id: 3, name: '삭제하기' },
+  ],
+  onClick,
+}: ContextOptionsProps) {
+  const firstOption = 'rounded-t-lg';
+  const bar = 'border-b border-d400 mx-2';
+  const lastOption = 'rounded-b-lg';
+  return (
+    <div className="bg-d10 m-2 border border-d400 rounded-lg">
+      {options.map((option, idx) => {
+        return (
+          <>
+            <div
+              className={`px-3 py-1 hover:bg-d30
+            ${idx === 0 && firstOption}
+            ${idx === options.length - 1 && lastOption}`}
+              key={option.id}
+              onClick={() => onClick(option.id)}
+            >
+              <p className="font-base text-d400">{option.name}</p>
+            </div>
+            {idx !== options.length - 1 && <div className={bar}></div>}
+          </>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/common/Options/ContextOptions.types.ts
+++ b/src/components/common/Options/ContextOptions.types.ts
@@ -1,0 +1,9 @@
+type List = {
+  id: number;
+  name: string;
+};
+
+export type ContextOptionsProps = {
+  options: List[];
+  onClick: (id: number) => void;
+};


### PR DESCRIPTION
### 작업 개요

- 관리자 우클릭 옵션 컴포넌트 구성
  - `/Options/ContextOptions`

### 반영 브랜치

ex) feat_common-component_options -> dev

### 연관된 이슈(optional)

- #5 

### 스크린샷(optional)

- **ContextOptions Storybook**
 ![image](https://github.com/user-attachments/assets/e4a0c451-5285-419c-bb11-324927417392)

### 기타 참고 사항(optional)

- 우클릭 옵션이 활성화 상태일때를 체크하고, 우클릭 옵션 이외의 화면에서 클릭이벤트가 감지될때, 우클릭 옵션 컴포넌트가 비활성화 되어야함
- 현 마우스 좌표를 확인하고, 마우스 좌표의 오른쪽에 배치되도록 해야함
- 이외 수정 사항 및 참고할만한 자료조사가 필요함.