### PR TITLE
[Feat] 공통 컴포넌트 input re

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-gitmessage.txt
+.gitmessage.txt
 
 # env files
 *.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "clsx": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -3713,6 +3714,15 @@
         "@chromatic-com/playwright": {
           "optional": true
         }
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface Props {
+  id: string;
+  label?: string;
+  type: React.HTMLInputTypeAttribute; // input의 type
+  placeholder: string;
+  iconUrl?: string; // icon svg 타입 찾기
+  onClickIcon?: () => void; // 상황에 맞는 API 요청
+  subText?: string; // input 하단 문구(경고 문구, 안내 문구)
+}
+
+export default function Input({
+  id,
+  label,
+  type,
+  placeholder,
+  iconUrl,
+  onClickIcon,
+  subText,
+}: Props) {
+  return (
+    <>
+      {label && (
+        <label className="text-lg font-semibold" htmlFor={id}>
+          {label}
+        </label>
+      )}
+      <div className="relative mt-2 mb-1">
+        <input
+          className="w-full px-4 py-2 rounded-lg text-base placeholder:text-d200 border border-d50"
+          type={type}
+          id={id}
+          placeholder={placeholder}
+        />
+        {iconUrl && (
+          <div className="absolute flex items-center justify-center right-4 top-0 h-full cursor-pointer">
+            <img className="w-5 h-5" src={iconUrl} alt="input icon image" onClick={onClickIcon} />
+          </div>
+        )}
+      </div>
+      {subText && <p className="w-full text-base text-d200">{subText}</p>}
+    </>
+  );
+}

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,13 +1,15 @@
+import clsx from 'clsx';
 import React from 'react';
+import { SubText } from './Input.type';
 
 interface Props {
   id: string;
   label?: string;
   type: React.HTMLInputTypeAttribute; // input의 type
   placeholder: string;
-  iconUrl?: string; // icon svg 타입 찾기
+  iconUrl?: string; // icon 이미지 url 찾기
   onClickIcon?: () => void; // 상황에 맞는 API 요청
-  subText?: string; // input 하단 문구(경고 문구, 안내 문구)
+  subText?: SubText; // input 하단 안내 문구
 }
 
 export default function Input({
@@ -22,7 +24,7 @@ export default function Input({
   return (
     <>
       {label && (
-        <label className="text-lg font-semibold" htmlFor={id}>
+        <label className="text-em font-semibold" htmlFor={id}>
           {label}
         </label>
       )}
@@ -39,7 +41,11 @@ export default function Input({
           </div>
         )}
       </div>
-      {subText && <p className="w-full text-base text-d200">{subText}</p>}
+      {subText && (
+        <p className={clsx('w-full text-base text-d200', subText.warn && 'text-highlightRed')}>
+          {subText.text}
+        </p>
+      )}
     </>
   );
 }

--- a/src/components/common/Input/Input.type.ts
+++ b/src/components/common/Input/Input.type.ts
@@ -1,0 +1,1 @@
+export type SubText = { text: string; warn?: boolean };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      fontSize: {
+        em: '1em',
+      },
       colors: {
         b50: '#e6f0ff',
         b75: '#96c0ff',
@@ -19,7 +22,7 @@ export default {
         d200: '#6b788e',
         d400: '#505f79',
         d700: '#c2c7d0',
-        d900: '#091e42',
+        d800: '#091e42',
 
         highlightRed: '#dc2626',
         highlightYellow: '#ffd446',


### PR DESCRIPTION
### 작업 개요

- 공통 컴포넌트 인풋 구현

### 반영 브랜치

feat_common-component_input-re -> dev

### 연관된 이슈(optional)

- #5 

### 변경 사항(optional)

- `.gitignore`: gitmessage.txt -> .gitmessage.txt 

### 스크린샷(optional)

- 모든 옵션 적용
![image](https://github.com/user-attachments/assets/aabb7fcb-47e1-467e-8454-ecc181faabcb)
- 경고 문구 옵션
![image](https://github.com/user-attachments/assets/2fb90703-8d36-4778-bcad-3b03f5c97791)
- 라벨 사이즈 변경
![image](https://github.com/user-attachments/assets/d63984b6-c960-455b-a33c-ff7ce69a9ddc)


### 기타 참고 사항(optional)

- 스토리북은 추후 추가 예정입니다
- 라벨에 대한 사이즈 변경은 em 단위로 부모의 font size에 비례합니다

### 체크리스트

- [ ] storybook 적용
- [x] 상황 별 동작을 잘 하는가?
  - 라벨 있고 없고
  - 서브 텍스트 있고 없고
- [x] 아이콘 동작은 잘 되는가?
  - 아이콘 변경 여부
  - 원하는 API 호출 여부
- [x] 서브 텍스트를 경고 문구로써 사용할 수 있는가?
