### PR TITLE
[Fix] 탭이 겹쳐서 분리가 안 되는 문제 해결

### DIFF
--- a/src/pages/Manage/Table/Tab.tsx
+++ b/src/pages/Manage/Table/Tab.tsx
@@ -10,7 +10,7 @@ export default function Tab({
   children,
 }: PropsWithChildren<TabProps>) {
   const leftPosition: { [key: number]: string } = {
-    0: `left-[0px]`,
+    0: 'left-[0px]',
     1: 'left-[130px]',
   }; // 고정된 160px에 대한 값
 

--- a/src/pages/Manage/Table/Tab.tsx
+++ b/src/pages/Manage/Table/Tab.tsx
@@ -4,23 +4,18 @@ import { TabProps } from './Tab.types';
 
 export default function Tab({
   id,
-  index,
+  leftPosition,
   currentTab,
   handleTabChange,
   children,
 }: PropsWithChildren<TabProps>) {
-  const leftPosition: { [key: number]: string } = {
-    0: 'left-[0px]',
-    1: 'left-[130px]',
-  }; // 고정된 160px에 대한 값
-
   return (
     <div
       key={id}
       className={clsx(
         'absolute top-0 flex h-[50px] min-w-[160px] items-center justify-center rounded-tr-[30px] border border-d900 text-2xl font-semibold',
-        leftPosition[index],
-        index === 0 && 'z-[1]',
+        leftPosition,
+        id === 'table' && 'z-[1]',
         id === currentTab ? 'bg-d900 text-d10' : 'cursor-pointer bg-d10 text-d900 hover:bg-b50'
       )}
       onClick={() => handleTabChange(id)}

--- a/src/pages/Manage/Table/Tab.tsx
+++ b/src/pages/Manage/Table/Tab.tsx
@@ -9,14 +9,17 @@ export default function Tab({
   handleTabChange,
   children,
 }: PropsWithChildren<TabProps>) {
-  const leftPosition = `left-[${130 * index}px]`; // 고정된 160px에 대한 값
+  const leftPosition: { [key: number]: string } = {
+    0: `left-[0px]`,
+    1: 'left-[130px]',
+  }; // 고정된 160px에 대한 값
 
   return (
     <div
       key={id}
       className={clsx(
         'absolute top-0 flex h-[50px] min-w-[160px] items-center justify-center rounded-tr-[30px] border border-d900 text-2xl font-semibold',
-        leftPosition,
+        leftPosition[index],
         index === 0 && 'z-[1]',
         id === currentTab ? 'bg-d900 text-d10' : 'cursor-pointer bg-d10 text-d900 hover:bg-b50'
       )}

--- a/src/pages/Manage/Table/Tab.types.ts
+++ b/src/pages/Manage/Table/Tab.types.ts
@@ -1,6 +1,10 @@
 export interface TabProps {
   id: string;
-  index: number;
+  /*
+    탭 길이가 고정된 160px에 대한 absolute left 값
+    탭 길이가 변경되는 경우 수정이 필요한 값
+  */
+  leftPosition: string;
   currentTab: string;
   handleTabChange: (id: string) => void;
 }

--- a/src/pages/Manage/TablePage.tsx
+++ b/src/pages/Manage/TablePage.tsx
@@ -45,17 +45,27 @@ export default function TablePage() {
   return (
     <div className="flex h-full flex-col">
       <Tabs>
-        <Tab id="table" index={0} currentTab={currentTab} handleTabChange={handleTabChange}>
+        <Tab
+          id="table"
+          leftPosition="left-[0px]"
+          currentTab={currentTab}
+          handleTabChange={handleTabChange}
+        >
           테이블
         </Tab>
-        <Tab id="qr" index={1} currentTab={currentTab} handleTabChange={handleTabChange}>
+        <Tab
+          id="qr"
+          leftPosition="left-[130px]"
+          currentTab={currentTab}
+          handleTabChange={handleTabChange}
+        >
           QR
         </Tab>
       </Tabs>
       {currentTab === 'table' ? (
         <div className="flex h-full flex-wrap content-start gap-5 overflow-y-scroll p-10">
           {tableList.map(table => (
-            <Table table={table} key={table.tableNo}/>
+            <Table table={table} key={table.tableNo} />
           ))}
           <div
             className="max-w-1/6 relative flex max-h-[170px] min-h-[155px] min-w-[240px] cursor-pointer flex-col items-center justify-center rounded-lg border border-d900 p-4 text-2xl font-bold text-d200 hover:text-d900"
@@ -68,7 +78,7 @@ export default function TablePage() {
         <>
           <div className="flex h-full flex-wrap content-start gap-5 overflow-y-scroll p-10">
             {tableList.map(({ tableNo }) => (
-              <QRCard tableNo={tableNo} key={tableNo}/>
+              <QRCard tableNo={tableNo} key={tableNo} />
             ))}
           </div>
           <div className="flex justify-center gap-2 py-[6px]">


### PR DESCRIPTION
### 작업 개요

- 테이블 관리 화면 상단 탭이 겹치는 문제 해결

### 반영 브랜치

fix_manage-table_tab -> dev

### 변경 사항(optional)

- `Tab.tsx`: leftPosition을 변수로 값을 변경하던 부분을 객체에 고정된 값을 넣는 것으로 변경

### 해결 과정(optional)

- tailwind에서는 동적으로 값을 변경하는 경우에 클래스 이름에 완전한 문자열을 사용해야 한다
```ts
const leftPosition = `left-[${130 * index}px]` // 기존 사용 방법

const leftPosition:{ [key: number] : string } = {
  0: 'left-[0px]',
  1: 'left-[130px]'
} // 수정한 사용 방법
```

### 기타 참고 사항(optional)

- [공식문서](https://tailwindcss.com/docs/content-configuration#dynamic-class-names)
- [참고글](https://1two13.tistory.com/entry/tailwind-css-%EB%8F%99%EC%A0%81%EC%9C%BC%EB%A1%9C-%ED%81%B4%EB%9E%98%EC%8A%A4-%ED%95%A0%EB%8B%B9%ED%95%98%EB%8A%94-%EB%B2%95#google_vignette)
