### PR TITLE
[Feat] login API 연동 및 기타 구현

### DIFF
--- a/src/apis/user.api.ts
+++ b/src/apis/user.api.ts
@@ -1,0 +1,8 @@
+import { UserLoginFormTypes } from '@/pages/AdminHome/AdminHome.types';
+import { axiosClient } from './axios';
+
+export const login = async (loginData: UserLoginFormTypes) => {
+  const response = await axiosClient.post('/users/login', loginData);
+
+  return response.data;
+};

--- a/src/components/common/Layout/ManageLayout.tsx
+++ b/src/components/common/Layout/ManageLayout.tsx
@@ -1,8 +1,9 @@
 import { Outlet } from 'react-router-dom';
-import { useState } from 'react';
 import FirstPage from '@/pages/Manage/Table/FirstPage';
+import useUserStore from '@/stores/useUserStore';
 
 export default function ManageLayout() {
+  const { loginFirst } = useUserStore();
   // TODO 첫 사용자라면, 가게 생성 작성
   // TODO 첫 사용자가 아니라면, /table 로 이동
   // TODO 사용자가 아니라면 / 로 이동
@@ -13,9 +14,7 @@ export default function ManageLayout() {
   */
   // TODO: 사용자가 리로드했을 때 => 로컬 스토리지
 
-  const [isFirstTime, setIsFirstTime] = useState(true);
-
-  if (isFirstTime) return <FirstPage setIsFirstTime={setIsFirstTime} />;
+  if (loginFirst) return <FirstPage />;
 
   return <Outlet />;
 }

--- a/src/pages/AdminHome/LoginPage.tsx
+++ b/src/pages/AdminHome/LoginPage.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/common/Button/Button';
 import Input from '@/components/common/Input/Input';
 import { loginInputList } from '@/pages/AdminHome/formFieldsData';
 import { UserLoginFormTypes } from './AdminHome.types';
+import { login } from '@/apis/user.api';
 
 export default function LoginPage() {
   const [loginForm, setLoginForm] = useState<UserLoginFormTypes>({
@@ -17,6 +18,20 @@ export default function LoginPage() {
     // TODO: 성공적으로 로그인되었을 떄, 사용자가 첫 사용인지 체크.
     // TODO: navigate options에 처음 사용자인지(등록한 가게가 있는지)에 대한 결과 전달
     navigate(`/${src}`);
+  };
+  const handleLogin = () => {
+    //TODO response에 대한 타입 처리
+    login(loginForm)
+      .then((res: { message: string; isFirstLogin: boolean }) => {
+        if (res.isFirstLogin) {
+          navigate('/admin/manage');
+        } else {
+          navigate('/admin/manage/table');
+        }
+      })
+      .catch(err => {
+        console.log(err);
+      });
   };
 
   const handleInputChange = (id: string, value: string) => {
@@ -37,7 +52,7 @@ export default function LoginPage() {
           />
         </div>
       ))}
-      <Button title="로그인" type="others" onClick={() => handleNavigate('admin/manage')} />
+      <Button title="로그인" type="others" onClick={handleLogin} />
       <div className="flex cursor-pointer gap-4 text-d900">
         <span className="underline hover:font-bold">비밀번호를 잃어버리셨나요 ?</span>
         <span className="underline hover:font-bold" onClick={() => handleNavigate('register')}>

--- a/src/pages/AdminHome/LoginPage.tsx
+++ b/src/pages/AdminHome/LoginPage.tsx
@@ -5,6 +5,7 @@ import Input from '@/components/common/Input/Input';
 import { loginInputList } from '@/pages/AdminHome/formFieldsData';
 import { UserLoginFormTypes } from './AdminHome.types';
 import { login } from '@/apis/user.api';
+import useUserStore from '@/stores/useUserStore';
 
 export default function LoginPage() {
   const [loginForm, setLoginForm] = useState<UserLoginFormTypes>({
@@ -12,6 +13,7 @@ export default function LoginPage() {
     password: '',
   });
   const navigate = useNavigate();
+  const { setLoginFirst } = useUserStore();
 
   const handleNavigate = (src: string) => {
     // TODO: 로그인 버튼을 통한 접속에 대한 처리가 필요함.
@@ -24,8 +26,10 @@ export default function LoginPage() {
     login(loginForm)
       .then((res: { message: string; isFirstLogin: boolean }) => {
         if (res.isFirstLogin) {
+          setLoginFirst(true);
           navigate('/admin/manage');
         } else {
+          setLoginFirst(false);
           navigate('/admin/manage/table');
         }
       })

--- a/src/pages/AdminHome/LoginPage.tsx
+++ b/src/pages/AdminHome/LoginPage.tsx
@@ -12,6 +12,7 @@ export default function LoginPage() {
     email: '',
     password: '',
   });
+  const [subText, setSubText] = useState({ text: '', warn: true });
   const navigate = useNavigate();
   const { setLoginFirst } = useUserStore();
 
@@ -34,6 +35,7 @@ export default function LoginPage() {
         }
       })
       .catch(err => {
+        setSubText(prev => ({ ...prev, text: '이메일/비밀번호를 확인해주세요.' }));
         console.log(err);
       });
   };
@@ -53,6 +55,7 @@ export default function LoginPage() {
             placeholder={placeholder}
             value={loginForm[id as keyof UserLoginFormTypes]}
             handleInputChange={e => handleInputChange(id, e.target.value)}
+            subText={subText}
           />
         </div>
       ))}

--- a/src/pages/AdminHome/LoginPage.tsx
+++ b/src/pages/AdminHome/LoginPage.tsx
@@ -34,9 +34,8 @@ export default function LoginPage() {
           navigate('/admin/manage/table');
         }
       })
-      .catch(err => {
+      .catch(() => {
         setSubText(prev => ({ ...prev, text: '이메일/비밀번호를 확인해주세요.' }));
-        console.log(err);
       });
   };
 

--- a/src/pages/Manage/Table/FirstPage.tsx
+++ b/src/pages/Manage/Table/FirstPage.tsx
@@ -3,10 +3,9 @@ import Input from '@/components/common/Input/Input';
 import { useState } from 'react';
 import { CircleArrow } from '@/assets/icons';
 import clsx from 'clsx';
-import { FirstPageProps } from './FirstPage.types';
 import Slider from '@/components/common/Slider/Slider';
 
-export default function FirstPage({ setIsFirstTime }: FirstPageProps) {
+export default function FirstPage() {
   const [defaultTableNum, setDefaultTableNum] = useState(0);
   const [shopName, setShopName] = useState('');
   const navigate = useNavigate();
@@ -22,7 +21,6 @@ export default function FirstPage({ setIsFirstTime }: FirstPageProps) {
     // TODO API 요청
     console.log('submit', `{defaultTableNum:${defaultTableNum}, shopName:${shopName}}`);
     // 성공 시 첫 입장 처리 및 화면 이동
-    setIsFirstTime(false);
     navigate('/admin/manage/table');
   };
 

--- a/src/pages/Manage/Table/FirstPage.types.tsx
+++ b/src/pages/Manage/Table/FirstPage.types.tsx
@@ -1,3 +1,0 @@
-export interface FirstPageProps {
-  setIsFirstTime: React.Dispatch<React.SetStateAction<boolean>>;
-}

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -3,12 +3,17 @@ import { UserType } from '@/types';
 
 type userState = {
   userInfo: UserType;
+  loginFirst: boolean;
+
+  setLoginFirst: (isFirstLogin: boolean) => void;
 };
 
-const useUserStore = create<userState>(() => ({
+const useUserStore = create<userState>(set => ({
   userInfo: {
     id: null,
   },
+  loginFirst: true,
+  setLoginFirst: isFirstLogin => set(() => ({ loginFirst: isFirstLogin })),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
### 작업 개요

- 로그인 API 연동
- 로그인 에러 시 에러 텍스트 출력

### 반영 브랜치

feat_admin-user_login -> dev

### 연관된 이슈(optional)

- #7

### 스크린샷(optional)

- 로그인 성공
![image](https://github.com/user-attachments/assets/6d424da7-d3a6-4cb0-9388-999dc508fa97)
- 로그인 실패
![image](https://github.com/user-attachments/assets/bc7774c8-f210-4aa4-9519-1cc5f653cb66)

### 기타 참고 사항(optional)

- useNavigate의 용도를 모르겠어서 navigate로 화면을 이동을 했습니다. 혹시 변경을 원하시면 리뷰 남겨주시거나 branch pull 받아서 수정 부탁 드립니다.
- 직접 수정 하신 경우 pr 참고 사항에 변경사항 남겨주시기 바라겠습니다.

### 체크리스트

- [x] 로그인이 되는가?
- [x] 쿠키에는 문제가 없는가?
- [x] 로그인 실패 시 에러 텍스트가 나오는가?
- [ ] 빈 인풋을 확인하는 에러 텍스트가 나오는가?
- [x] fix_api_cookie 브랜치 dev에 merge 후 base 변경하고 merge하기
- [ ] console.log() 코드 삭제
