### PR TITLE
[Fix] API 쿠키 에러 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 # env files
 *.env
 *storybook.log
+
+# ssl files
+*.pem

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 import 'dotenv/config';
+
+const fileName = fileURLToPath(import.meta.url);
+const dirName = path.dirname(fileName);
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -19,6 +25,12 @@ export default defineConfig({
     }),
     tsconfigPaths(),
   ],
+  server: {
+    https: {
+      key: fs.readFileSync(path.resolve(dirName, 'key.pem')),
+      cert: fs.readFileSync(path.resolve(dirName, 'cert.pem')),
+    },
+  },
   define: {
     'process.env': process.env,
   },


### PR DESCRIPTION
### 작업 개요

- API를 연동 쿠키 설정 수정

### 반영 브랜치

fix_api_cookie -> dev

### 연관된 이슈(optional)

- #43 

### 변경 사항(optional)

- vite http -> https로 변경
- project 루트 디렉토리에 key.pem과 cert.pem 생성

### 해결 과정(optional)

- [react에서 localhost 개발환경 https 적용](https://velog.io/@sslgo15/React%EC%97%90%EC%84%9C-localhost-%EA%B0%9C%EB%B0%9C%ED%99%98%EA%B2%BD-https-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
- [__dirname 에러](https://velog.io/@juice-han/dirname-is-not-defined-in-ES-module-scope-%EC%98%A4%EB%A5%98%EC%9D%98-%EC%9B%90%EC%9D%B8%EA%B3%BC-%ED%95%B4%EA%B2%B0%EB%B0%A9%EB%B2%95)
- vite.config.ts
```ts
https: {
  key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
  cert: fs.readFileSync(path.resolve(__dirname, 'localhost-cert.pem')),
},
```

### 기타 참고 사항(optional)

- pem 파일은 mkcert를 이용해서 local에서 생성해서 사용해야 합니다.
