### PR TITLE
[Feat] 관리자 Menu API 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.3.1",
         "react-qr-code": "^2.0.15",
         "react-router-dom": "^6.26.2",
+        "uuid": "^10.0.0",
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^5.0.1",
         "zustand": "^5.0.0-rc.2"
@@ -1532,6 +1533,20 @@
       },
       "peerDependencies": {
         "storybook": "^8.3.2"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -8548,10 +8563,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-dom": "^18.3.1",
     "react-qr-code": "^2.0.15",
     "react-router-dom": "^6.26.2",
+    "uuid": "^10.0.0",
     "vite-plugin-svgr": "^4.2.0",
     "vite-tsconfig-paths": "^5.0.1",
     "zustand": "^5.0.0-rc.2"

--- a/src/apis/setting/menu.api.ts
+++ b/src/apis/setting/menu.api.ts
@@ -1,0 +1,59 @@
+import { SetMenuData, SetOptionsData } from '@/types';
+import { axiosClient } from '../axios';
+
+export const getCategories = async () => {
+  const response = await axiosClient.get('/categories');
+
+  return response.data;
+};
+
+export const addCategories = async (categoryName: string) => {
+  const response = await axiosClient.post('/categories', { categoryName: categoryName });
+
+  return response.data.categoryId;
+};
+
+export const deleteCategories = async (categoryId: string) => {
+  return await axiosClient.delete(`/categories/${categoryId}`);
+};
+
+export const deleteMenu = async (menuId: string) => {
+  return await axiosClient.delete(`/menus/${menuId}`);
+};
+
+export const getMenu = async () => {
+  const response = await axiosClient.get('/menus');
+
+  return response.data;
+};
+
+export const addMenu = async (menuForm: SetMenuData) => {
+  const response = await axiosClient.post('/menus', menuForm);
+
+  return response.data.menuId;
+};
+
+export const applyMenu = async (menuForm: SetMenuData, menuId: string) => {
+  const response = await axiosClient.put(`/menus/${menuId}`, menuForm);
+
+  return response.data;
+};
+
+export const setMenuImage = async (file: File) => {
+  const formData = new FormData();
+  formData.append('upload', file);
+
+  const response = await axiosClient.post('/img-upload', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return response.data;
+};
+
+export const addMenuOptionsForm = async (optionsForm: SetOptionsData[], menuId: string) => {
+  const response = await axiosClient.post(`/options/${menuId}`, optionsForm);
+
+  return response.data;
+};

--- a/src/components/MenuBox/AddOptionsBox.tsx
+++ b/src/components/MenuBox/AddOptionsBox.tsx
@@ -20,7 +20,7 @@ export default function AddOptionsBox({
           <div key={id} className="flex items-center gap-2 pl-4 pr-2">
             <div className="w-[60%]">
               <Input
-                id={`optionName-${id}`}
+                id={`optionName_${id}`}
                 type="text"
                 placeholder="옵션 이름"
                 value={optionName}
@@ -29,7 +29,7 @@ export default function AddOptionsBox({
             </div>
             <div className="w-[30%]">
               <Input
-                id={`price-${id}`}
+                id={`price_${id}`}
                 type="text"
                 placeholder="가격"
                 value={price}
@@ -46,7 +46,7 @@ export default function AddOptionsBox({
         ))}
       </div>
       <div className="flex items-center justify-center gap-3">
-        <Plus width="24" height="24" onClick={onAddOptions} className="cursor-pointer" />
+        <Plus width="24" height="24" onClick={onAddOptions} className="cursor-pointer fill-d900" />
       </div>
     </div>
   );

--- a/src/components/MenuBox/CategoryBox.tsx
+++ b/src/components/MenuBox/CategoryBox.tsx
@@ -5,18 +5,27 @@ import { Plus } from '@/assets/icons';
 import { CategoryBoxProps } from './MenuBox.types';
 
 export default function CategoryBox({
+  message,
   category,
   onCategory,
   onSetInputMenuForm,
   onOpenCategoryOptions,
 }: CategoryBoxProps) {
-  const { categories } = useMenuStore();
+  const { categories, menus } = useMenuStore();
+
+  const isCategoryActive = (categoryId: string) => {
+    return menus.some(menu => menu.category === categoryId);
+  };
 
   return (
-    <div className="flex h-fit min-w-[620px] flex-col gap-3 rounded-lg border border-d50 px-3 py-4">
+    <div className="flex h-fit min-w-[620px] flex-col gap-4 rounded-lg border border-d50 px-3 py-4">
       <div className="flex min-h-[54px] items-center justify-between gap-3 px-3">
-        <p className="text-2xl font-bold">카테고리 추가하기</p>
-        <div>
+        <div className="relative w-full font-bold">
+          <p className="text-2xl">카테고리 추가하기</p>
+          <p className="absolute text-base text-highlightRed">{message}</p>
+        </div>
+
+        <div className="min-w-[180px]">
           <Input
             id="category"
             type="text"
@@ -25,7 +34,7 @@ export default function CategoryBox({
             handleInputChange={onSetInputMenuForm}
             onClickIcon={() => onCategory(1)}
           >
-            <Plus width="16" height="16" />
+            <Plus width="16" height="16" className="fill-d900" />
           </Input>
         </div>
       </div>
@@ -34,7 +43,7 @@ export default function CategoryBox({
           <ItemButton
             key={id}
             title={title}
-            state="normal"
+            state={isCategoryActive(id) ? 'active' : 'normal'}
             onContextMenu={e => onOpenCategoryOptions(e, id)}
           />
         ))}

--- a/src/components/MenuBox/FastToolBox.tsx
+++ b/src/components/MenuBox/FastToolBox.tsx
@@ -7,7 +7,7 @@ export default function FastToolBox({ onToggleTool }: FastToolBoxProps) {
   const { selectedTools } = useMenuStore();
 
   return (
-    <div className="flex h-fit w-full flex-col gap-3 rounded-lg border border-d50 px-3 py-4">
+    <div className="flex h-fit w-full flex-col gap-4 rounded-lg border border-d50 px-3 py-4">
       <div className="flex min-h-[54px] items-center gap-1 px-3 text-2xl font-bold">
         <span>빠르고 쉬운 도구</span>
         <span className="text-b500">Beta</span>

--- a/src/components/MenuBox/MainMenuBox.tsx
+++ b/src/components/MenuBox/MainMenuBox.tsx
@@ -20,16 +20,15 @@ export default function MainMenuBox({
   onSearchMenu,
   onToggleMenu,
   onSetMenu,
-  onDeleteMenu,
+  onCancelMenu,
 }: MainMenuBoxProps) {
-  
   const { categories, menus, selectedMenu } = useMenuStore();
-  
+
   return (
     <div className="flex h-fit min-w-[620px] flex-col gap-3 rounded-lg border border-d50 px-3 py-4">
       <div className="mx-3 flex min-h-[54px] items-center justify-between gap-3 border-b border-d50 pb-3">
         <p className="text-2xl font-bold">메뉴 추가하기</p>
-        <Plus width="24" onClick={onAddMenu} className="cursor-pointer" />
+        <Plus width="24" onClick={onAddMenu} className="cursor-pointer fill-d900" />
       </div>
       <div className="mx-3 border-b border-d50 pb-3">
         <Input
@@ -65,7 +64,11 @@ export default function MainMenuBox({
                   idx !== menus.length - 1 && 'border-b border-d50 pb-4'
                 )}
               >
-                {menu.image ? <img /> : <NoImage width="48" height="48" />}
+                {menu.image ? (
+                  <img src={menu.image} alt="Menu Preview" className="h-12 w-12 object-cover" />
+                ) : (
+                  <NoImage width="48" height="48" />
+                )}
                 <div className="flex w-full flex-col">
                   <div className="flex w-full justify-between">
                     <span className="text-xl">{menu.title}</span>
@@ -95,7 +98,7 @@ export default function MainMenuBox({
                         width="20"
                         height="20"
                         className="cursor-pointer"
-                        onClick={() => onDeleteMenu(menu.id)}
+                        onClick={() => onCancelMenu(menu.id)}
                       />
                     </div>
                   </div>

--- a/src/components/MenuBox/ManageMenuBox.tsx
+++ b/src/components/MenuBox/ManageMenuBox.tsx
@@ -1,17 +1,30 @@
 import useMenuStore from '@/stores/useMenuStore';
 import { Save, Exclamation, NoImage, Edit, Plus } from '@/assets/icons';
 import { ManageMenuBoxProps } from './MenuBox.types';
+import { ChangeEvent } from 'react';
+import clsx from 'clsx';
+import { setMenuImage } from '@/apis/setting/menu.api';
 
 export default function ManageMenuBox({
+  warn,
   inputMenuForm,
   onSetInputMenuForm,
   onSaveMenu,
   onSelectCategory,
   onAddMenuImage,
   onEditOptions,
-  onDeleteMenu,
+  onCancelMenu,
 }: ManageMenuBoxProps) {
   const { categories } = useMenuStore();
+
+  const handleImageUpload = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] as File;
+
+    setMenuImage(file).then(res => {
+      onAddMenuImage(res.data.imageUrl);
+    });
+  };
+
   return (
     <div className="flex h-fit w-[50%] flex-col rounded-lg border border-d50 px-2 py-4">
       <div className="mx-3 flex items-center justify-between border-b border-d50 pb-3">
@@ -19,7 +32,10 @@ export default function ManageMenuBox({
           id="menuName"
           type="text"
           value={inputMenuForm.menuName}
-          className="bg-d10 text-xl placeholder:text-d200"
+          className={clsx(
+            'bg-d10 text-xl',
+            warn ? 'placeholder:text-highlightRed' : 'placeholder:text-d200'
+          )}
           size={10}
           placeholder="메뉴 이름"
           onChange={onSetInputMenuForm}
@@ -36,7 +52,10 @@ export default function ManageMenuBox({
             id="description"
             type="text"
             value={inputMenuForm.description}
-            className="bg-d10 placeholder:text-d200"
+            className={clsx(
+              'bg-d10',
+              warn ? 'placeholder:text-highlightRed' : 'placeholder:text-d200'
+            )}
             placeholder="메뉴 설명을 적어주세요."
             onChange={onSetInputMenuForm}
           />
@@ -47,7 +66,11 @@ export default function ManageMenuBox({
             <Exclamation width="16" height="16" />
           </div>
           <div className="flex w-full items-center">
-            <select className="w-full rounded border bg-d10 p-2" onChange={onSelectCategory}>
+            <select
+              className="w-full rounded border bg-d10 p-2"
+              onChange={onSelectCategory}
+              value={inputMenuForm.menuCategory}
+            >
               {categories.map(({ id, title }) => (
                 <option key={id} value={id}>
                   {title}
@@ -65,7 +88,10 @@ export default function ManageMenuBox({
             id="price"
             type="text"
             value={inputMenuForm.price}
-            className="bg-d10 placeholder:text-d200"
+            className={clsx(
+              'bg-d10',
+              warn ? 'placeholder:text-highlightRed' : 'placeholder:text-d200'
+            )}
             placeholder="가격을 적어주세요."
             onChange={onSetInputMenuForm}
           />
@@ -79,7 +105,10 @@ export default function ManageMenuBox({
             id="origin"
             type="text"
             value={inputMenuForm.origin}
-            className="bg-d10 placeholder:text-d200"
+            className={clsx(
+              'bg-d10',
+              warn ? 'placeholder:text-highlightRed' : 'placeholder:text-d200'
+            )}
             placeholder="ex) 배추: 국내산, 고춧가루: 국내산"
             onChange={onSetInputMenuForm}
           />
@@ -87,9 +116,35 @@ export default function ManageMenuBox({
         <div className="my-3 flex items-center justify-between">
           <div className="flex flex-col">
             <span className="text-lg">메뉴 사진 추가</span>
-            <span className="text-d200">사용하지 않음</span>
+            {inputMenuForm.image ? <></> : <span className="text-d200">사용하지 않음</span>}
           </div>
-          <NoImage className="cursor-pointer" width="48" height="48" onClick={onAddMenuImage} />
+          {inputMenuForm.image ? (
+            <label htmlFor="menuImageUpload" className="cursor-pointer">
+              <img
+                src={inputMenuForm.image}
+                alt="Menu Preview"
+                className="h-12 w-12 object-cover"
+              />
+              <input
+                id="menuImageUpload"
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleImageUpload}
+              />
+            </label>
+          ) : (
+            <label htmlFor="menuImageUpload" className="cursor-pointer">
+              <NoImage width="48" height="48" />
+              <input
+                id="menuImageUpload"
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleImageUpload}
+              />
+            </label>
+          )}
         </div>
         <div className="my-3 flex flex-col">
           <div className="flex items-center justify-between">
@@ -115,8 +170,8 @@ export default function ManageMenuBox({
         <Plus
           width="24"
           height="24"
-          onClick={() => onDeleteMenu()}
-          className="rotate-45 cursor-pointer"
+          onClick={() => onCancelMenu()}
+          className="rotate-45 cursor-pointer fill-d900"
         />
       </div>
     </div>

--- a/src/components/MenuBox/MenuBox.types.ts
+++ b/src/components/MenuBox/MenuBox.types.ts
@@ -2,14 +2,15 @@ import { AddOptionsTypes, InputMenuFormTypes } from '@/types';
 import { ChangeEvent, MouseEvent } from 'react';
 
 export type CategoryBoxProps = {
+  message: string;
   category: string;
   onCategory: (id: number) => void;
   onSetInputMenuForm: (e: ChangeEvent<HTMLInputElement>) => void;
-  onOpenCategoryOptions: (e: MouseEvent, id: number) => void;
+  onOpenCategoryOptions: (e: MouseEvent, id: string) => void;
 };
 
 export type FastToolBoxProps = {
-  onToggleTool: (toolId: number) => void;
+  onToggleTool: (toolId: string) => void;
 };
 
 export type MainMenuBoxProps = {
@@ -17,25 +18,26 @@ export type MainMenuBoxProps = {
   onAddMenu: () => void;
   onSetInputMenuForm: (e: ChangeEvent<HTMLInputElement>) => void;
   onSearchMenu: () => void;
-  onToggleMenu: (menuId: number) => void;
-  onSetMenu: (menuId: number) => void;
-  onDeleteMenu: (menuId?: number) => void;
+  onToggleMenu: (menuId: string) => void;
+  onSetMenu: (menuId: string) => void;
+  onCancelMenu: (menuId?: string) => void;
 };
 
 export type ManageMenuBoxProps = {
+  warn: boolean;
   inputMenuForm: InputMenuFormTypes;
   onSetInputMenuForm: (e: ChangeEvent<HTMLInputElement>) => void;
   onSaveMenu: () => void;
   onSelectCategory: (e: ChangeEvent<HTMLSelectElement>) => void;
-  onAddMenuImage: () => void;
+  onAddMenuImage: (imgUrl: string) => void;
   onEditOptions: () => void;
-  onDeleteMenu: (menuId?: number) => void;
+  onCancelMenu: (menuId?: string) => void;
 };
 
 export type AddOptionsBoxProps = {
   optionsInput: AddOptionsTypes[];
   onSaveOptions: () => void;
   onSetInputOption: (e: ChangeEvent<HTMLInputElement>) => void;
-  onDeleteOptions: (optionId: number) => void;
+  onDeleteOptions: (optionId: string) => void;
   onAddOptions: () => void;
 };

--- a/src/pages/Manage/Table/DeatailModal.tsx
+++ b/src/pages/Manage/Table/DeatailModal.tsx
@@ -14,7 +14,7 @@ export default function DetailModal({ currentTable, onCloseModal, onInitTable }:
       <ModalTitle>
         <div className="relative text-3xl font-bold">
           <Plus
-            className="absolute right-0 top-0 rotate-45 cursor-pointer"
+            className="absolute right-0 top-0 rotate-45 cursor-pointer fill-d900"
             width={25}
             height={25}
             onClick={onCloseModal}

--- a/src/pages/Setting/MenuPage.tsx
+++ b/src/pages/Setting/MenuPage.tsx
@@ -10,7 +10,7 @@ import {
   ManageMenuBox,
 } from '@/components/MenuBox';
 import { MENU_CATEGORY_OPTIONS } from '@/constants/options';
-import { InputMenuFormTypes, SetOptionsData } from '@/types';
+import { InputMenuFormTypes, SetMenuData, SetOptionsData } from '@/types';
 import {
   addCategories,
   addMenu,
@@ -69,7 +69,9 @@ export default function MenuPage() {
     });
 
     getMenu().then(menuData => {
-      const activeMenuIds = menuData.filter(menu => menu.isActive).map(menu => menu.id);
+      const activeMenuIds = menuData
+        .filter((menu: SetMenuData) => menu.isActive)
+        .map((menu: SetMenuData) => menu.id);
       setSelectedMenu(activeMenuIds);
       setMenu(menuData);
     });

--- a/src/pages/Setting/MenuPage.tsx
+++ b/src/pages/Setting/MenuPage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEvent, useState } from 'react';
+import { ChangeEvent, MouseEvent, useState, useEffect } from 'react';
 import useContextMenuStore from '@/stores/useContextMenuStore';
 import ContextOptions from '@/components/common/Options/ContextOptions';
 import useMenuStore from '@/stores/useMenuStore';
@@ -10,7 +10,18 @@ import {
   ManageMenuBox,
 } from '@/components/MenuBox';
 import { MENU_CATEGORY_OPTIONS } from '@/constants/options';
-import { InputMenuFormTypes } from '@/types';
+import { InputMenuFormTypes, SetOptionsData } from '@/types';
+import {
+  addCategories,
+  addMenu,
+  deleteCategories,
+  getCategories,
+  getMenu,
+  deleteMenu,
+  applyMenu,
+  addMenuOptionsForm,
+} from '@/apis/setting/menu.api';
+import { v4 as uuidv4 } from 'uuid';
 
 export default function MenuPage() {
   const { openMenu, isVisible, parentId } = useContextMenuStore();
@@ -18,12 +29,17 @@ export default function MenuPage() {
     menus,
     currentId,
     step,
+    categories,
+    selectedMenu,
+    setCategories,
     addCategory,
     deleteCategory,
     setCurrentId,
+    setSelectedMenu,
     setStep,
+    setMenu,
     saveMenu,
-    deleteMenu,
+    cancelMenu,
     toggleMenu,
     toggleTool,
   } = useMenuStore();
@@ -33,35 +49,63 @@ export default function MenuPage() {
     search: '',
     menuName: '',
     description: '',
-    menuCategory: 1,
+    menuCategory: '',
     price: '',
     origin: '',
     options: null,
-    optionsInput: [{ id: 1, optionName: '', price: '' }],
+    image: '',
+    optionsInput: [{ id: '1', optionName: '', price: '' }], // id를 string으로 변환
   });
 
-  const onSelectCategory = (e: ChangeEvent<HTMLSelectElement>) => {
+  const [warnMessage, setWarnMessage] = useState({
+    type: '',
+    message: '',
+  });
+
+  useEffect(() => {
+    getCategories().then(categories => {
+      setCategories(categories);
+      setInputMenuForm(prev => ({ ...prev, menuCategory: categories[0].id }));
+    });
+
+    getMenu().then(menuData => {
+      const activeMenuIds = menuData.filter(menu => menu.isActive).map(menu => menu.id);
+      setSelectedMenu(activeMenuIds);
+      setMenu(menuData);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (warnMessage.type) {
+      const messageTimer = setTimeout(() => {
+        setWarnMessage({ type: '', message: '' });
+      }, 3000);
+      return () => clearTimeout(messageTimer);
+    }
+  }, [warnMessage]);
+
+  const handleSelectCategory = (e: ChangeEvent<HTMLSelectElement>) => {
     setInputMenuForm(prev => ({
       ...prev,
-      menuCategory: Number(e.target.value),
+      menuCategory: e.target.value,
     }));
   };
 
-  const onSetInputOption = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleSetInputOption = (e: ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
-    const [field, optionId] = id.split('-');
+    const [field, optionId] = id.split('_');
 
     setInputMenuForm(prevForm => ({
       ...prevForm,
       optionsInput: prevForm.optionsInput
         ? prevForm.optionsInput.map(optionInput =>
-            optionInput.id === Number(optionId) ? { ...optionInput, [field]: value } : optionInput
+            optionInput.id === optionId ? { ...optionInput, [field]: value } : optionInput
           )
         : [],
     }));
   };
 
-  const onSetInputMenuForm = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleSetInputMenuForm = (e: ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
     setInputMenuForm(prev => ({
       ...prev,
@@ -69,47 +113,77 @@ export default function MenuPage() {
     }));
   };
 
-  const onCategory = (id: number) => {
-    // TODO: 매직넘버 상수화 필요
+  const handleCategory = (id: number) => {
     if (id === 1) {
-      addCategory(inputMenuForm.category);
-      setInputMenuForm(prev => ({
-        ...prev,
-        category: '',
-      }));
+      if (!inputMenuForm.category)
+        return setWarnMessage(() => ({
+          type: 'category',
+          message: '카테고리 이름을 입력하지 않았어요.',
+        }));
+      if (categories.length >= 10)
+        return setWarnMessage(() => ({
+          type: 'category',
+          message: '더이상 카테고리를 생성할 수 없어요.',
+        }));
+      if (categories.find(category => category.title === inputMenuForm.category))
+        return setWarnMessage(() => ({
+          type: 'category',
+          message: '동일한 카테고리 이름을 가지고 있어요.',
+        }));
+
+      addCategories(inputMenuForm.category).then(id => {
+        addCategory(id, inputMenuForm.category);
+        setInputMenuForm(prev => ({
+          ...prev,
+          category: '',
+        }));
+      });
     } else if (id === 3) {
-      // TODO: 카테고리가 1개 이하일때 경고
-      deleteCategory(parentId);
+      if (categories.length <= 1)
+        return setWarnMessage(() => ({
+          type: 'category',
+          message: '더이상 카테고리를 삭제할 수 없어요.',
+        }));
+      const isActiveCategory = menus.some(menu => menu.category === parentId);
+      if (isActiveCategory) {
+        // TODO:경고모달
+      } else {
+        deleteCategories(parentId).then(() => deleteCategory(parentId));
+      }
     }
   };
 
-  const onOpenCategoryOptions = (e: MouseEvent, id: number) => {
+  const handleOpenCategoryOptions = (e: MouseEvent, id: string) => {
     const { clientX: x, clientY: y } = e;
     openMenu(id, x, y);
   };
 
-  const onAddMenu = () => {
+  const handleAddMenu = () => {
     setStep(2);
   };
-  const onSearchMenu = () => {};
-  const onDeleteMenu = (menuId?: number) => {
-    if (menuId) deleteMenu(menuId);
+  const handleSearchMenu = () => {};
+  const handleCancelMenu = (menuId?: string) => {
+    if (menuId) {
+      cancelMenu(menuId);
+      deleteMenu(menuId);
+    }
     setInputMenuForm({
       category: '',
       search: '',
       menuName: '',
       description: '',
-      menuCategory: 1,
+      menuCategory: categories[0].id,
       price: '',
       origin: '',
+      image: '',
       options: null,
-      optionsInput: [{ id: 1, optionName: '', price: '' }],
+      optionsInput: [{ id: '1', optionName: '', price: '' }],
     });
 
     setStep(1);
   };
 
-  const onSetMenu = (menuId: number) => {
+  const handleSetMenu = (menuId: string) => {
     const menu = menus.find(menu => menu.id === menuId);
     if (menu) {
       const addOptions = menu.addOptions
@@ -120,7 +194,7 @@ export default function MenuPage() {
           }))
         : null;
 
-      const addOptionsInput = addOptions ? addOptions : [{ id: 1, optionName: '', price: '' }];
+      const addOptionsInput = addOptions ? addOptions : [{ id: '1', optionName: '', price: '' }];
 
       setInputMenuForm(prev => ({
         ...prev,
@@ -130,6 +204,7 @@ export default function MenuPage() {
         price: menu.price.toString(),
         origin: menu.origin,
         options: addOptions,
+        image: menu.image || '',
         optionsInput: addOptionsInput,
       }));
       setStep(2);
@@ -137,80 +212,185 @@ export default function MenuPage() {
     }
   };
 
-  const onSaveMenu = () => {
-    const { menuCategory, menuName, description, price, origin, options } = inputMenuForm;
+  const handleSaveMenu = () => {
+    const { menuCategory, menuName, description, price, origin, options, image } = inputMenuForm;
     if (menuCategory && menuName && description && price && origin) {
       const addOptions = options?.map(({ optionName, price }, idx) => ({
-        id: idx + 1,
+        id: String(idx + 1),
         optionName,
         price: Number(price),
       }));
 
       const menuData = {
-        id: currentId === 0 ? Math.max(...menus.map(menu => menu.id)) + 1 : currentId,
+        id: currentId,
         title: menuName,
         description,
-        category: Number(menuCategory),
+        category: menuCategory,
         price: Number(price),
         origin,
+        image,
         addOptions: addOptions?.length ? addOptions : null,
       };
-      saveMenu(menuData);
+
+      if (currentId) {
+        // 옵션 적용해서 생성 혹은 변경
+        applyMenu(
+          {
+            categoryId: menuCategory,
+            menuName: menuName,
+            price: Number(price),
+            menuDetail: description,
+            menuImg: image,
+            origin: origin,
+          },
+          currentId
+        ).then(() => saveMenu(menuData));
+      } else {
+        // 옵션 없이 생성
+        addMenu({
+          categoryId: menuCategory,
+          menuName: menuName,
+          price: Number(price),
+          menuDetail: description,
+          menuImg: image,
+          origin: origin,
+        }).then(id => {
+          const menuData = {
+            id: id,
+            title: menuName,
+            description,
+            category: menuCategory,
+            price: Number(price),
+            origin,
+            image,
+            addOptions: addOptions?.length ? addOptions : null,
+          };
+          saveMenu(menuData);
+        });
+      }
+
       setInputMenuForm({
         category: '',
         search: '',
         menuName: '',
         description: '',
-        menuCategory: 1,
+        menuCategory: categories[0].id,
         price: '',
         origin: '',
+        image: '',
         options: null,
-        optionsInput: [{ id: 1, optionName: '', price: '' }],
+        optionsInput: [{ id: '1', optionName: '', price: '' }],
       });
       setStep(1);
+    } else
+      setWarnMessage(prev => ({
+        ...prev,
+        type: 'menu',
+      }));
+  };
+
+  const handleAddMenuImage = (imageUrl: string) => {
+    setInputMenuForm(prev => ({
+      ...prev,
+      image: imageUrl,
+    }));
+  };
+
+  const handleEditOptions = () => {
+    const { menuCategory, menuName, description, price, origin, image } = inputMenuForm;
+
+    if (menuCategory && menuName && description && price && origin) {
+      if (!currentId)
+        // 임시 세이브
+        addMenu({
+          categoryId: menuCategory,
+          menuName: menuName,
+          price: Number(price),
+          menuDetail: description,
+          menuImg: image,
+          origin: origin,
+        }).then(id => setCurrentId(id));
+      setInputMenuForm(prev => ({
+        ...prev,
+        optionsInput: prev.options || [{ id: uuidv4(), optionName: '', price: '' }],
+      }));
+      setStep(3);
+    } else {
+      setWarnMessage(prev => ({
+        ...prev,
+        type: 'menu',
+      }));
     }
   };
-  const onAddMenuImage = () => {};
 
-  const onEditOptions = () => {
-    setStep(3);
-  };
-
-  const onAddOptions = () => {
-    // TODO: 최대갯수 제한 (ex:10)
+  const handleAddOptions = () => {
     setInputMenuForm(prev => {
-      const newId = prev.optionsInput.length
-        ? prev.optionsInput[prev.optionsInput.length - 1].id + 1
-        : 1;
       return {
         ...prev,
-        optionsInput: [...(prev.optionsInput || []), { id: newId, optionName: '', price: '' }],
+        optionsInput: [...(prev.optionsInput || []), { id: uuidv4(), optionName: '', price: '' }],
       };
     });
   };
 
-  const onDeleteOptions = (optionId: number) => {
-    // TODO: api 연결
+  const handleDeleteOptions = (optionId: string) => {
     setInputMenuForm(prev => ({
       ...prev,
-      optionsInput: prev.optionsInput.filter(optionInput => optionInput.id !== optionId) || [], // id가 다른 옵션들만 남기기
+      optionsInput: prev.optionsInput.filter(optionInput => optionInput.id !== optionId) || [], // id가 다른 옵션들만 남기기 (string 비교)
     }));
   };
 
-  const onSaveOptions = () => {
-    // TODO: api 연결
-    // TODO: 옵션이름, 가격이 들어가있지 않은 경우
-    setInputMenuForm(prev => ({
-      ...prev,
-      options: prev.optionsInput,
-    }));
+  const handleSaveOptions = () => {
+    const validOptions = inputMenuForm.optionsInput
+      .filter(optionInput => optionInput.optionName && optionInput.price) // Ensure both fields are present
+      .map(optionInput => ({
+        optionName: optionInput.optionName,
+        optionPrice: Number(optionInput.price),
+      }));
+
+    addMenuOptionsForm(validOptions, currentId).then(options => {
+      const newOptions = options.map((option: SetOptionsData) => ({
+        id: option.id,
+        optionName: option.optionName,
+        price: option.optionPrice,
+      }));
+      setInputMenuForm(prev => ({
+        ...prev,
+        options: newOptions,
+        optionsInput: [{ id: '1', optionName: '', price: '' }],
+      }));
+    });
     setStep(2);
   };
 
-  const onToggleMenu = (menuId: number) => {
-    toggleMenu(menuId);
+  const handleToggleMenu = (menuId: string) => {
+    const currentMenu = menus.find(menu => menu.id === menuId);
+
+    if (!currentMenu) return;
+
+    // console.log({
+    //   categoryId: currentMenu.category,
+    //   menuName: currentMenu.title,
+    //   price: currentMenu.price,
+    //   menuDetail: currentMenu.description,
+    //   menuImg: currentMenu.image || '',
+    //   origin: currentMenu.origin,
+    //   isActive: !selectedMenu.includes(menuId),
+    // });
+    // TODO: TOGGLE 기능 필요
+    applyMenu(
+      {
+        categoryId: currentMenu.category,
+        menuName: currentMenu.title,
+        price: currentMenu.price,
+        menuDetail: currentMenu.description,
+        menuImg: currentMenu.image || '',
+        origin: currentMenu.origin,
+        isActive: !selectedMenu.includes(menuId),
+      },
+      menuId
+    ).then(() => toggleMenu(menuId));
   };
-  const onToggleTool = (toolId: number) => {
+  const handleToggleTool = (toolId: string) => {
     toggleTool(toolId);
   };
 
@@ -218,49 +398,51 @@ export default function MenuPage() {
     <div className="flex flex-col gap-4">
       <div className="flex h-[180px] w-full gap-3">
         <CategoryBox
+          message={warnMessage.type === 'category' ? warnMessage.message : ''}
           category={inputMenuForm.category}
-          onCategory={onCategory}
-          onSetInputMenuForm={onSetInputMenuForm}
-          onOpenCategoryOptions={onOpenCategoryOptions}
+          onCategory={handleCategory}
+          onSetInputMenuForm={handleSetInputMenuForm}
+          onOpenCategoryOptions={handleOpenCategoryOptions}
         />
-        <FastToolBox onToggleTool={onToggleTool} />
+        <FastToolBox onToggleTool={handleToggleTool} />
       </div>
       <div className="flex w-full gap-3">
         <MainMenuBox
           search={inputMenuForm.search}
-          onAddMenu={onAddMenu}
-          onSetInputMenuForm={onSetInputMenuForm}
-          onSearchMenu={onSearchMenu}
-          onToggleMenu={onToggleMenu}
-          onSetMenu={onSetMenu}
-          onDeleteMenu={onDeleteMenu}
+          onAddMenu={handleAddMenu}
+          onSetInputMenuForm={handleSetInputMenuForm}
+          onSearchMenu={handleSearchMenu}
+          onToggleMenu={handleToggleMenu}
+          onSetMenu={handleSetMenu}
+          onCancelMenu={handleCancelMenu}
         />
         <div className="flex w-full gap-3">
           {step !== 1 && (
             <ManageMenuBox
+              warn={warnMessage.type === 'menu'}
               inputMenuForm={inputMenuForm}
-              onSetInputMenuForm={onSetInputMenuForm}
-              onSaveMenu={onSaveMenu}
-              onSelectCategory={onSelectCategory}
-              onAddMenuImage={onAddMenuImage}
-              onEditOptions={onEditOptions}
-              onDeleteMenu={onDeleteMenu}
+              onSetInputMenuForm={handleSetInputMenuForm}
+              onSaveMenu={handleSaveMenu}
+              onSelectCategory={handleSelectCategory}
+              onAddMenuImage={handleAddMenuImage}
+              onEditOptions={handleEditOptions}
+              onCancelMenu={handleCancelMenu}
             />
           )}
           {step === 3 ? (
             <AddOptionsBox
               optionsInput={inputMenuForm.optionsInput}
-              onSaveOptions={onSaveOptions}
-              onSetInputOption={onSetInputOption}
-              onDeleteOptions={onDeleteOptions}
-              onAddOptions={onAddOptions}
+              onSaveOptions={handleSaveOptions}
+              onSetInputOption={handleSetInputOption}
+              onDeleteOptions={handleDeleteOptions}
+              onAddOptions={handleAddOptions}
             />
           ) : (
             <div className="w-[50%]"></div>
           )}
         </div>
       </div>
-      {isVisible && <ContextOptions options={MENU_CATEGORY_OPTIONS} onClick={onCategory} />}
+      {isVisible && <ContextOptions options={MENU_CATEGORY_OPTIONS} onClick={handleCategory} />}
     </div>
   );
 }

--- a/src/stores/menuData.ts
+++ b/src/stores/menuData.ts
@@ -9,7 +9,7 @@ export const categoryData = [
 ];
 
 export const easyFastToolData = [
-  { id: 1, title: '직원호출' },
-  { id: 2, title: '영수증' },
-  { id: 3, title: '자리이동' },
+  { id: '1', title: '직원호출' },
+  { id: '2', title: '영수증' },
+  { id: '3', title: '자리이동' },
 ];

--- a/src/stores/useContextMenuStore.ts
+++ b/src/stores/useContextMenuStore.ts
@@ -1,19 +1,19 @@
 import { create } from 'zustand';
 
 type ContextMenuState = {
-  parentId: number;
+  parentId: string;
   isVisible: boolean;
   position: { x: number; y: number };
-  openMenu: (id: number, x: number, y: number) => void;
+  openMenu: (id: string, x: number, y: number) => void;
   closeMenu: () => void;
 };
 
 const useContextMenuStore = create<ContextMenuState>(set => ({
-  parentId: 0,
+  parentId: '0',
   isVisible: false,
   position: { x: 0, y: 0 },
   openMenu: (id, x, y) => set({ parentId: id, isVisible: true, position: { x, y } }),
-  closeMenu: () => set({ parentId: 0, isVisible: false }),
+  closeMenu: () => set({ parentId: '0', isVisible: false }),
 }));
 
 export default useContextMenuStore;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,7 @@ export interface InputField {
 }
 
 export type AddOptionsTypes = {
-  id: number;
+  id: string;
   optionName: string;
   price: string;
 };
@@ -25,9 +25,10 @@ export type InputMenuFormTypes = {
   search: string;
   menuName: string;
   description: string;
-  menuCategory: number;
+  menuCategory: string;
   price: string;
   origin: string;
+  image: string;
   options: AddOptionsTypes[] | null;
   optionsInput: AddOptionsTypes[];
 };
@@ -79,4 +80,22 @@ export type InputEtcFormTypes = {
   tools: {
     prepayment: boolean;
   };
+};
+
+export type SetMenuData = {
+  id?: string;
+  categoryId: string;
+  menuName: string;
+  price: number;
+  menuDetail: string;
+  menuImg: string;
+  origin: string | null;
+  options?: SetOptionsData[];
+  isActive?: boolean;
+};
+
+export type SetOptionsData = {
+  id?: string;
+  optionName: string;
+  optionPrice: number;
 };


### PR DESCRIPTION
### 작업 개요

- 관리자 Menu API 구현
  - getCategories `/categories` `GET` => 카테고리 조회
  - addCategories `/categories`, `POST` => 카테고리 생성
  - deleteCategories `/categories/:categoryId`, `DELETE` => 카테고리 삭제
  - getMenu `/menus`, `GET` => 메뉴 조회
  - addMenu `/menus`, `POST` => 메뉴 생성
  - deleteMenu `/menus/:menuId`, `DELETE` => 메뉴 삭제
  - applyMenu `/menus/:menuId`, `PUT` => 메뉴 수정
  - setMenuImage `/img-upload`, `POST` => 이미지 업로드
  - addMenuOptionsForm `/options/:menuId`, `POST` => 추가옵션 생성/수정/삭제

- 예외상황 처리
  - [x] 카테고리 10개 이상 생성 금지
  - [x] 카테고리 최소 갯수 제한
  - [x] 사용자 필수 입력 경고 메세지
  - [ ] 등록된 카테고리 경고 모달
  
### 반영 브랜치

ex) feat_setting-menu_api -> dev

### 연관된 이슈(optional)

- #10 
