### PR TITLE
[Feat] 소비자 API 연동 - 가게 및 기타 구현

### DIFF
--- a/src/apis/customer.api.ts
+++ b/src/apis/customer.api.ts
@@ -1,0 +1,78 @@
+import { axiosClient } from './axios';
+
+/*
+토큰 발급
+
+데이터 조합
+- 메뉴
+- 카테고리
+- 가게 정보(이름, 설명)
+- 디자인 정보
+*/
+type ResponseToken = {
+  message: string;
+};
+
+export const getCustomerToken = async (data: any) => {
+  const response = await axiosClient.post<ResponseToken>('/customerJwt', data);
+
+  return response.status;
+};
+
+type ResponseRestaurant = {
+  id: string;
+  name: string;
+  defaultTableCount: number;
+  totalTableCount: number;
+  logo: string;
+  introduce: string;
+  comment: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const getRestaurantData = async () => {
+  const response = await axiosClient.get<ResponseRestaurant>('/restaurants');
+
+  return response.data;
+};
+
+type ResponseMenu = {
+  id: string;
+  categoryId: string;
+  menuName: string;
+  price: number;
+  menuDetail: string;
+  menuImg: string | null;
+  origin: string | null;
+  isActive: boolean; //라벨  defaul;
+  soldOut: boolean; //라벨   defaul;
+  hot: boolean; //라벨  defaul;
+  new: boolean; //라벨  defaul;
+  isRunningOut: boolean; //라벨   defaul;
+  created_at: string;
+  updated_at: string;
+  options: ResponseOption[];
+};
+
+type ResponseOption = { id: string; menuId: string; optionName: string; optionPrice: string };
+
+export const getMenuData = async () => {
+  const response = await axiosClient.get<ResponseMenu[]>('/menus');
+
+  return response.data;
+};
+
+type ResponseCategory = {
+  id: string;
+  categoryName: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export const getCategoryData = async () => {
+  const response = await axiosClient.get<ResponseCategory[]>('/categories');
+
+  return response.data;
+};
+

--- a/src/apis/customer.api.ts
+++ b/src/apis/customer.api.ts
@@ -43,19 +43,19 @@ type ResponseMenu = {
   menuName: string;
   price: number;
   menuDetail: string;
-  menuImg: string | null;
-  origin: string | null;
-  isActive: boolean; //라벨  defaul;
-  soldOut: boolean; //라벨   defaul;
-  hot: boolean; //라벨  defaul;
-  new: boolean; //라벨  defaul;
-  isRunningOut: boolean; //라벨   defaul;
+  menuImg: string;
+  origin: string;
+  isActive: boolean;
+  soldOut: boolean;
+  hot: boolean;
+  new: boolean;
+  isRunningOut: boolean;
   created_at: string;
   updated_at: string;
   options: ResponseOption[];
 };
 
-type ResponseOption = { id: string; menuId: string; optionName: string; optionPrice: string };
+type ResponseOption = { id: string; menuId: string; optionName: string; optionPrice: number };
 
 export const getMenuData = async () => {
   const response = await axiosClient.get<ResponseMenu[]>('/menus');
@@ -75,4 +75,3 @@ export const getCategoryData = async () => {
 
   return response.data;
 };
-

--- a/src/components/common/Layout/CustomerLayout.tsx
+++ b/src/components/common/Layout/CustomerLayout.tsx
@@ -1,6 +1,39 @@
-import { Outlet } from 'react-router-dom';
+import { getCustomerToken } from '@/apis/customer.api';
+import useCustomerStore from '@/stores/useCustomerStore';
+import { useEffect } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 export default function CustomerLayout() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setCustomerTableNo } = useCustomerStore();
+
+  const handleMoveHome = async () => {
+    if (location.search !== '') {
+      try {
+        const [restaurantId, tableNum] = location.search
+          .replace('?restaurant_id=', '')
+          .replace('&table_num=', ',')
+          .split(',');
+        const jwtStatus = await getCustomerToken({
+          restaurantId,
+          tableNum,
+        });
+
+        if (jwtStatus === 200) {
+          setCustomerTableNo(Number(tableNum));
+          navigate('/customer/home');
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
+
+  useEffect(() => {
+    handleMoveHome();
+  }, []);
+
   return (
     <div className="flex h-screen w-full items-center justify-around bg-b50">
       <div className="max-[1024px]:hidden lg:text-lg lg:font-bold lg:text-gray-700">

--- a/src/components/customer/ListItem.tsx
+++ b/src/components/customer/ListItem.tsx
@@ -1,25 +1,24 @@
 import { Option, SquareMinus, SquarePlus, Trash } from '@/assets/icons';
 import IconButton from '@/components/customer/IconButton';
 import { ListItem as TListItem } from '@/stores/useCustomerStore';
-import { useState } from 'react';
 
 interface ListItemProps {
-  item?: TListItem; // 타입 재정의 후 사용예정
+  item: TListItem;
   variant: 'order' | 'cart';
   onRemoveCartItem?: () => void;
   onReduceMenuQuantity?: () => void;
   onIncreaseMenuQuantity?: () => void;
 }
 
-export default function ListItem({ variant }: ListItemProps) {
-  const [menuQuantity] = useState(1);
+export default function ListItem({ item, variant }: ListItemProps) {
+  const { menu, quantity, totalPrice } = item;
 
   return (
     <div className="flex w-full flex-col gap-1 rounded-lg border border-d80 px-4 py-2">
-      <div className="text-xs font-bold text-d200">category</div>
-      <div className="text-xl font-bold">menu name</div>
-      <div className="text-xs text-d200">options</div>
-      <div className="text-sm font-bold">order price</div>
+      <div className="text-xs font-bold text-d200">{menu.categoryName}</div>
+      <div className="text-xl font-bold">{menu.menuName}</div>
+      <div className="text-xs text-d200">{menu.options.join('/')}</div>
+      <div className="text-sm font-bold">{totalPrice}</div>
       {/* 수량 조절 */}
       {variant === 'cart' && (
         <div className="mt-2 flex items-center justify-between text-xl font-bold">
@@ -33,7 +32,7 @@ export default function ListItem({ variant }: ListItemProps) {
           >
             <Option />
           </IconButton>
-          {menuQuantity === 1 ? (
+          {quantity === 1 ? (
             <button className="flex h-5 w-5 items-center justify-center">
               <Trash />
             </button>
@@ -42,10 +41,10 @@ export default function ListItem({ variant }: ListItemProps) {
               <SquareMinus />
             </button>
           )}
-          <div className="w-6 text-center">{menuQuantity}</div>
+          <div className="w-6 text-center">{quantity}</div>
           <button
             className="flex h-6 w-6 items-center justify-center disabled:text-d80"
-            disabled={menuQuantity === 10}
+            disabled={quantity === 10}
           >
             <SquarePlus />
           </button>
@@ -53,7 +52,7 @@ export default function ListItem({ variant }: ListItemProps) {
       )}
       {variant === 'order' && (
         <div className="flex text-lg">
-          주문 수량: <div className="w-6 text-center">{1}</div>개
+          주문 수량: <div className="w-6 text-center">{quantity}</div>개
         </div>
       )}
     </div>

--- a/src/components/customer/MenuCard.tsx
+++ b/src/components/customer/MenuCard.tsx
@@ -9,6 +9,8 @@ interface CustomerMenuCardProps {
 }
 
 export default function CustomerMenuCard({ menu, onOpenMenuDetail }: CustomerMenuCardProps) {
+  const { menuName, menuDetail, price } = menu;
+
   return (
     <div
       className={clsx(
@@ -22,9 +24,9 @@ export default function CustomerMenuCard({ menu, onOpenMenuDetail }: CustomerMen
         <NoImage />
       </div>
       <div className="flex flex-1 flex-col justify-evenly gap-1 px-1">
-        <div className="text-base font-bold">{menu.title}</div>
-        <div className="text-xs text-d200">{menu.description}</div>
-        <div className="text-right text-sm font-bold">{menu.price.toLocaleString()}원</div>
+        <div className="text-base font-bold">{menuName}</div>
+        <div className="text-xs text-d200">{menuDetail}</div>
+        <div className="text-right text-sm font-bold">{price.toLocaleString()}원</div>
       </div>
     </div>
   );

--- a/src/components/customer/MenuCard.tsx
+++ b/src/components/customer/MenuCard.tsx
@@ -9,7 +9,7 @@ interface CustomerMenuCardProps {
 }
 
 export default function CustomerMenuCard({ menu, onOpenMenuDetail }: CustomerMenuCardProps) {
-  const { menuName, menuDetail, price } = menu;
+  const { menuName, menuDetail, price, menuImg } = menu;
 
   return (
     <div
@@ -21,7 +21,7 @@ export default function CustomerMenuCard({ menu, onOpenMenuDetail }: CustomerMen
     >
       <div className="relative flex h-20 w-20 items-center justify-center">
         <MenuOption optType={menu.hot ? 'hot' : menu.new ? 'new' : menu.soldOut ? 'soldOut' : ''} />
-        <NoImage />
+        {menuImg === '' ? <NoImage /> : <img src={menuImg} alt="메뉴 이미지" />}
       </div>
       <div className="flex flex-1 flex-col justify-evenly gap-1 px-1">
         <div className="text-base font-bold">{menuName}</div>

--- a/src/pages/Customer/CustomerDetailMenuPage.tsx
+++ b/src/pages/Customer/CustomerDetailMenuPage.tsx
@@ -15,7 +15,7 @@ export default function CustomerDetailMenuPage() {
     return null;
   }
 
-  const { menuName, menuDetail, origin, price, options } = selectedMenu;
+  const { menuName, menuDetail, menuImg, origin, price, options } = selectedMenu;
 
   const handleReduceMenuQuantity = () => {
     // TODO 수량 조절 로직
@@ -38,9 +38,13 @@ export default function CustomerDetailMenuPage() {
       <NavHeader>{menuName}</NavHeader>
       {/* 메뉴 설명 */}
       <div className="flex flex-col border-b border-d50 px-2 py-6">
+        {menuImg === '' ? (
         <div className="mb-4 flex h-40 w-[80%] items-center justify-center self-center bg-d30">
           <NoImage />
         </div>
+        ) : (
+          <img className="h-40 w-[80%] self-center" src={menuImg} alt="메뉴 이미지" />
+        )}
         <div className="text-base text-d200">{menuDetail}</div>
         <div className="text-base text-d200">{origin}</div>
       </div>

--- a/src/pages/Customer/CustomerDetailMenuPage.tsx
+++ b/src/pages/Customer/CustomerDetailMenuPage.tsx
@@ -39,9 +39,9 @@ export default function CustomerDetailMenuPage() {
       {/* 메뉴 설명 */}
       <div className="flex flex-col border-b border-d50 px-2 py-6">
         {menuImg === '' ? (
-        <div className="mb-4 flex h-40 w-[80%] items-center justify-center self-center bg-d30">
-          <NoImage />
-        </div>
+          <div className="mb-4 flex h-40 w-[80%] items-center justify-center self-center bg-d30">
+            <NoImage />
+          </div>
         ) : (
           <img className="h-40 w-[80%] self-center" src={menuImg} alt="메뉴 이미지" />
         )}
@@ -90,7 +90,7 @@ export default function CustomerDetailMenuPage() {
       <div className="flex w-full justify-end gap-1 p-2 text-xl font-bold">
         주문 금액:
         <div className="w-24 text-end">
-          {(options
+          {(options.length
             ? price * menuQuantity +
               selectedOptions.reduce((a, optionNo) => a + options[optionNo].optionPrice, 0)
             : price * menuQuantity

--- a/src/pages/Customer/CustomerDetailMenuPage.tsx
+++ b/src/pages/Customer/CustomerDetailMenuPage.tsx
@@ -15,7 +15,7 @@ export default function CustomerDetailMenuPage() {
     return null;
   }
 
-  const { title, description, origin, price, options } = selectedMenu;
+  const { menuName, menuDetail, origin, price, options } = selectedMenu;
 
   const handleReduceMenuQuantity = () => {
     // TODO 수량 조절 로직
@@ -35,13 +35,13 @@ export default function CustomerDetailMenuPage() {
   return (
     <div className="flex h-full flex-col overflow-y-scroll">
       {/* 헤더 */}
-      <NavHeader>{title}</NavHeader>
+      <NavHeader>{menuName}</NavHeader>
       {/* 메뉴 설명 */}
       <div className="flex flex-col border-b border-d50 px-2 py-6">
         <div className="mb-4 flex h-40 w-[80%] items-center justify-center self-center bg-d30">
           <NoImage />
         </div>
-        <div className="text-base text-d200">{description}</div>
+        <div className="text-base text-d200">{menuDetail}</div>
         <div className="text-base text-d200">{origin}</div>
       </div>
       {/* 메뉴 옵션 */}

--- a/src/pages/Customer/CustomerHomePage.tsx
+++ b/src/pages/Customer/CustomerHomePage.tsx
@@ -1,3 +1,13 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 export default function CustomerHomePage() {
+  const navigate = useNavigate();
+
+  // TODO 클릭 시 화면 이동으로 변경하기
+  useEffect(() => {
+    setTimeout(() => navigate('/customer/menu'), 500);
+  }, []);
+
   return <div>CustomerHomePage</div>;
 }

--- a/src/pages/Customer/CustomerMenuPage.tsx
+++ b/src/pages/Customer/CustomerMenuPage.tsx
@@ -1,4 +1,5 @@
 import { Basket, Bell, List, OrderList } from '@/assets/icons';
+import { getCategoryData, getMenuData, getRestaurantData } from '@/apis/customer.api';
 import ItemButton from '@/components/common/Button/ItemButton';
 import CustomerMenuCard from '@/components/customer/MenuCard';
 import {
@@ -10,28 +11,76 @@ import {
 } from '@/constants/routing';
 import useCustomerStore, { Menu } from '@/stores/useCustomerStore';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 
 export default function CustomerMenuPage() {
   const navigate = useNavigate();
-  const { categories, menus, selectedCategory, selectMenu } = useCustomerStore();
+  const {
+    customerTableNo,
+    restaurantInfo,
+    categories,
+    menus,
+    selectedCategory,
+    selectMenu,
+    changeCategory,
+    setRestaurantInfo,
+    setCategories,
+    setMenus,
+  } = useCustomerStore();
 
-  const handleChangeCategory = () => {
-    // TODO 카테고리 변경
+  const handleFetchData = async () => {
+    try {
+      const restaurantData = await getRestaurantData();
+      const menuData = await getMenuData();
+      const categoryData = await getCategoryData();
+      const mappedCategory: { [key: string]: string } = {};
+
+      categoryData
+        // 메인요리 카테고리가 항상 맨 앞으로 오고 그 이후에는 생성된 시간으로 오름차순 정렬
+        .sort((a, b) =>
+          a.categoryName === '메인요리'
+            ? -1
+            : b.categoryName === '메인요리'
+              ? 1
+              : new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        )
+        .forEach(({ id, categoryName }) => {
+          mappedCategory[id] = categoryName;
+        });
+
+      setRestaurantInfo({
+        name: restaurantData.name,
+        introduce: restaurantData.introduce,
+        logo: restaurantData.logo,
+      });
+
+      setCategories(mappedCategory);
+
+      setMenus(menuData.map(menu => ({ ...menu, categoryName: mappedCategory[menu.categoryId] })));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  const handleChangeCategory = (category: string) => {
+    changeCategory(category);
   };
   const handleOpenMenuDetail = (menu: Menu) => {
-    // TODO 메뉴 상세 화면 열기
     selectMenu(menu);
     navigate(`/${ROUTE_CUSTOMER}/${ROUTE_CUSTOMER_DETAIL_MENU}`);
   };
+
+  useEffect(() => {
+    handleFetchData();
+  }, []);
 
   return (
     <div className="flex flex-col gap-2">
       {/* 가게이름 및 네비게이션 */}
       <div className="mr-2 mt-2 flex items-center justify-between">
         <div className="flex h-9 w-9 items-center justify-center rounded-r-lg border bg-b50 text-xl font-semibold">
-          1
+          {customerTableNo}
         </div>
-        <div className="text-2xl font-bold text-d900">restaurantName</div>
+        <div className="text-2xl font-bold text-d900">{restaurantInfo?.name}</div>
         <nav>
           <ol className="flex gap-3">
             <li className="flex h-7 w-[1.5rem] items-center justify-center">
@@ -59,23 +108,21 @@ export default function CustomerMenuPage() {
         </nav>
       </div>
       {/* 가게 설명 */}
-      <div className="mx-3 text-d900">message</div>
+      <div className="mx-3 text-d900">{restaurantInfo?.introduce}</div>
       {/* 카테고리 */}
       <div className="flex justify-between gap-2 border-y border-d50 px-1 py-2">
         <div className="flex min-w-[100px] max-w-[390px] gap-2 overflow-x-scroll text-nowrap rounded-md">
           <ItemButton
-            data-id={0}
             title="전체"
-            state={selectedCategory === 0 ? 'select' : 'normal'}
-            onClick={handleChangeCategory}
+            state={selectedCategory === '' ? 'select' : 'normal'}
+            onClick={() => handleChangeCategory('')}
           />
-          {categories.map(({ id, title }) => (
+          {Object.values(categories).map(category => (
             <ItemButton
-              key={id}
-              data-id={id}
-              title={title}
-              state={selectedCategory === id ? 'select' : 'normal'}
-              onClick={handleChangeCategory}
+              key={category}
+              title={category}
+              state={selectedCategory === category ? 'select' : 'normal'}
+              onClick={() => handleChangeCategory(category)}
             />
           ))}
         </div>
@@ -93,7 +140,12 @@ export default function CustomerMenuPage() {
       <div className="flex flex-col gap-2 px-2">
         {menus
           // 실시간 메뉴에서 액티브인 경우만 소비자 화면에 출력
-          // .filter(({ isActive }) => isActive === true)
+          .filter(({ isActive }) => isActive === true)
+          // 카테고리 필터링
+          .filter(({ categoryName }) => {
+            if (selectedCategory === '') return true;
+            return categoryName === selectedCategory;
+          })
           .map(menu => (
             <CustomerMenuCard
               key={menu.id}

--- a/src/stores/useCustomerStore.ts
+++ b/src/stores/useCustomerStore.ts
@@ -15,8 +15,8 @@ export type Menu = {
   menuName: string;
   price: number;
   menuDetail: string;
-  menuImg: string | null;
-  origin: string | null;
+  menuImg: string;
+  origin: string;
   isActive: boolean;
   soldOut: boolean;
   hot: boolean;

--- a/src/stores/useCustomerStore.ts
+++ b/src/stores/useCustomerStore.ts
@@ -1,41 +1,70 @@
 import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 type Option = {
-  id: number;
+  id: string;
+  menuId: string;
   optionName: string;
-  optionPrice: number;
+  optionPrice: string;
 };
 
 export type Menu = {
-  id: number;
-  title: string;
-  description: string;
-  category: number;
+  id: string;
+  categoryId: string;
+  categoryName: string;
+  menuName: string;
   price: number;
+  menuDetail: string;
+  menuImg: string | null;
+  origin: string | null;
+  isActive: boolean;
+  soldOut: boolean;
   hot: boolean;
   new: boolean;
-  soldOut: boolean;
-  origin: string;
-  image?: string;
-  options?: Option[];
+  isRunningOut: boolean;
+  created_at: string;
+  updated_at: string;
+  options: Option[];
 };
 
-// TODO menu 관리자 작업 후 타입 재정의 필요
+type ListItemMenu = {
+  categoryName: string;
+  menuName: string;
+  options: string[];
+};
+
 export type ListItem = {
   id: string;
-  menu: Menu;
+  menu: ListItemMenu;
   quantity: number;
+  totalPrice: number;
+};
+
+type RestaurantInfo = { name: string; logo: string; introduce: string };
+
+type Category = {
+  [key: string]: string;
 };
 
 type CustomerState = {
-  categories: { id: number; title: string }[];
-  selectedCategory: number;
+  customerTableNo: number;
 
-  changeCategory: (categoryId: number) => void;
+  setCustomerTableNo: (tableNo: number) => void;
+
+  restaurantInfo: RestaurantInfo | null;
+
+  setRestaurantInfo: (newInfo: RestaurantInfo) => void;
+
+  categories: Category;
+  selectedCategory: string;
+
+  setCategories: (newCategories: Category) => void;
+  changeCategory: (category: string) => void;
 
   menus: Menu[];
   selectedMenu: Menu | null;
 
+  setMenus: (newMenus: Menu[]) => void;
   selectMenu: (menu: Menu) => void;
 
   cart: ListItem[];
@@ -44,101 +73,45 @@ type CustomerState = {
   deleteCartItem: () => void;
 
   orders: ListItem[];
+  setOrders: (newOrders: ListItem[]) => void;
 };
 
-const useCustomerStore = create<CustomerState>(set => ({
-  categories: [
-    { id: 1, title: '메인메뉴' },
-    { id: 2, title: '한정메뉴' },
-    { id: 3, title: '사이드메뉴' },
-    { id: 4, title: '주류' },
-    { id: 5, title: '기타' },
-  ],
-  selectedCategory: 0,
-  changeCategory: () => {},
-  menus: [
-    {
-      id: 1,
-      title: '샘플 1',
-      description: '샘플 1 내용',
-      category: 1,
-      price: 5000,
-      hot: false,
-      new: false,
-      soldOut: false,
-      origin: '돼지고기: 국내산, 배추김치: 국내산',
-      options: [
-        {
-          id: 1,
-          optionName: '곱빼기',
-          optionPrice: 1000,
-        },
-      ],
+const useCustomerStore = create<CustomerState>()(
+  devtools(set => ({
+    customerTableNo: Number(localStorage.getItem('tableNo') ?? 0),
+    setCustomerTableNo: customerTableNo => {
+      localStorage.setItem('tableNo', customerTableNo.toString());
+      set(() => ({ customerTableNo }));
     },
-    {
-      id: 2,
-      title: '샘플 2',
-      description: '샘플 2 내용',
-      category: 2,
-      price: 5000,
-      hot: false,
-      new: false,
-      soldOut: false,
-      origin: '돼지고기: 국내산, 배추김치: 국내산',
-      options: [
-        {
-          id: 2,
-          optionName: '곱빼기',
-          optionPrice: 2000,
-        },
-      ],
+    restaurantInfo: null,
+    setRestaurantInfo: restaurantInfo => {
+      set(() => ({ restaurantInfo }));
     },
-    {
-      id: 3,
-      title: '샘플 3',
-      description: '샘플 3 내용',
-      category: 3,
-      price: 5000,
-      hot: false,
-      new: false,
-      soldOut: false,
-      origin: '돼지고기: 국내산, 배추김치: 국내산',
-      options: [
-        {
-          id: 3,
-          optionName: '곱빼기',
-          optionPrice: 3000,
-        },
-      ],
+    categories: {},
+    selectedCategory: '',
+    setCategories: categories => {
+      set(() => ({ categories }));
     },
-    {
-      id: 4,
-      title: '샘플 4',
-      description: '샘플 4 내용',
-      category: 4,
-      price: 5000,
-      hot: false,
-      new: false,
-      soldOut: false,
-      origin: '돼지고기: 국내산, 배추김치: 국내산',
-      options: [
-        {
-          id: 4,
-          optionName: '곱빼기',
-          optionPrice: 4000,
-        },
-      ],
+    changeCategory: selectedCategory => {
+      set(() => ({ selectedCategory }));
     },
-  ],
-  selectedMenu: null,
-  selectMenu: selectedMenu => {
-    set(() => ({ selectedMenu }));
-  },
-  cart: [],
-  addCartItem: () => {},
-  changeCartItem: () => {},
-  deleteCartItem: () => {},
-  orders: [],
-}));
+    menus: [],
+    selectedMenu: null,
+    setMenus: menus => {
+      set(() => ({ menus }));
+    },
+    selectMenu: selectedMenu => {
+      set(() => ({ selectedMenu }));
+    },
+    cart: [],
+    addCartItem: () => {},
+    changeCartItem: () => {},
+    deleteCartItem: () => {},
+    orders: [],
+    setOrders: orders => {
+      set(() => ({ orders }));
+    },
+  }))
+);
 
 export default useCustomerStore;

--- a/src/stores/useCustomerStore.ts
+++ b/src/stores/useCustomerStore.ts
@@ -5,7 +5,7 @@ type Option = {
   id: string;
   menuId: string;
   optionName: string;
-  optionPrice: string;
+  optionPrice: number;
 };
 
 export type Menu = {


### PR DESCRIPTION
### 작업 개요

- 소비자 화면에서 기본적으로 필요한 API 연동
- 카테고리 변경 및 필터링

### 반영 브랜치

feat_customer-api_store -> dev

### 연관된 이슈(optional)

- #53 

### 스크린샷(optional)

- 기본 화면
![image](https://github.com/user-attachments/assets/a19df45e-a61a-4553-a36c-078aee1749cb)
- 메뉴 상세 화면
![image](https://github.com/user-attachments/assets/fe02b425-3e5a-4bcb-9321-e2a993c3de01)
- 카테고리 적용 화면
![image](https://github.com/user-attachments/assets/59fc02e0-ef5f-4a50-8002-803febc1c693)

### 기타 참고 사항(optional)

- 동작만 하도록 구현했기 때문에 코드가 상당히 엉망일 수 있습니다.

### 체크리스트

- [x] 첫 접속 시 토큰을 받아오는가? 
- [x] 서버에서 데이터를 잘 불러오는가?
