### PR TITLE
[Fix] 테이블 주문 목록이 테이블을 넘어가는 에러

### DIFF
--- a/src/pages/Manage/Table/Table.tsx
+++ b/src/pages/Manage/Table/Table.tsx
@@ -3,16 +3,26 @@ import { TableProps } from './Table.types';
 import { Trash } from '@/assets/icons';
 import WarnModalContainer from '@/components/common/Modal/WarnModalContainer';
 import ModalTitle from '@/components/common/Modal/Content/ModalTitle';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, useEffect, useState } from 'react';
 import ModalContent from '@/components/common/Modal/Content/ModalContent';
 import ModalButton from '@/components/common/Modal/Button/ModalButton';
 import useRestaurantStore from '@/stores/useRestaurantStore';
+import clsx from 'clsx';
 
 export default function Table({ table, onModalOpen }: TableProps) {
   const { tableNo, orderList, totalPrice, newOrderNo } = table;
   const { deleteTable } = useTableStore();
   const [openWarnModal, setOpenWarnModal] = useState(false);
   const { restaurant } = useRestaurantStore();
+  const [isOverflow, setIsOverflow] = useState(false);
+
+  useEffect(() => {
+    const $ol = document.querySelectorAll('ol')[tableNo - 1];
+
+    if ($ol) {
+      setIsOverflow($ol.offsetHeight < $ol.scrollHeight);
+    }
+  }, [tableNo]);
 
   // TODO 서버 요청 구현 필요
   const handleDeleteTable = () => {
@@ -33,6 +43,7 @@ export default function Table({ table, onModalOpen }: TableProps) {
   return (
     <>
       <div
+        id={`${tableNo}-table`}
         className="max-w-1/6 relative flex max-h-[170px] min-h-[155px] min-w-[240px] cursor-pointer flex-col rounded-lg border border-d900 p-4 text-d900"
         onClick={handleModalOpen}
       >
@@ -49,13 +60,14 @@ export default function Table({ table, onModalOpen }: TableProps) {
             </div>
           )}
         </div>
-        <ol className="flex-1 px-2 py-1">
-          {orderList.map(({ menuName, menuQuantity }) => (
-            <li key={menuName}>
+        <ol className={clsx('flex-1 px-2 py-1', isOverflow && 'overflow-y-hidden')}>
+          {orderList.map(({ menuName, menuQuantity }, index) => (
+            <li key={index}>
               {menuName}*{menuQuantity}
             </li>
           ))}
         </ol>
+        {isOverflow && <div className="px-2">...</div>}
         <div className="w-full text-right text-xl font-bold">{totalPrice.toLocaleString()}원</div>
       </div>
       <WarnModalContainer open={openWarnModal}>


### PR DESCRIPTION
### 작업 개요

- 테이블 주문 목록이 테이블을 넘어가는 에러 수정

### 반영 브랜치

fix_manage-table_table-tab -> dev

### 스크린샷(optional)

- 적용된 테이블
![image](https://github.com/user-attachments/assets/83cfbbf9-39af-41cd-8ebe-f2ffa34e272e)

### 해결 과정(optional)

- ol 요소(주문 목록)의 offsetHeight와 scrollHeight를 비교해 offsetHeight가 작은 경우 overflow가 되는 것을 체크 후 isOverflow state 적용

### 기타 참고 사항(optional)

- [overflow 확인 로직 참고](https://stackoverflow.com/questions/42012130/how-to-detect-overflow-of-react-component-without-reactdom)

### 체크리스트

- [x] 정상 동작하는가?
