### PR TITLE
[Fix] 테이블 관리 화면 새로 고침 오류 수정

### DIFF
--- a/src/pages/Manage/TablePage.tsx
+++ b/src/pages/Manage/TablePage.tsx
@@ -26,7 +26,7 @@ type WarnModalData = {
 
 // TODO 함수명 통일하기
 export default function TablePage() {
-  const [currentTab, setCurrentTab] = useState('table');
+  const [currentTab, setCurrentTab] = useState(localStorage.getItem('currentTab') ?? 'table');
   const [openDetailModal, setOpenDetailModal] = useState(false);
   const [openWarnModal, setOpenWarnModal] = useState(false);
   const [warnModalData, setWarnModalData] = useState<WarnModalData>();
@@ -51,6 +51,7 @@ export default function TablePage() {
     addTable();
   };
   const handleTabChange = (id: string) => {
+    localStorage.setItem('currentTab', `${id}`);
     setCurrentTab(id);
   };
   const handleDetailModalOpen = (table: TTable) => {

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -12,8 +12,13 @@ const useUserStore = create<userState>(set => ({
   userInfo: {
     id: null,
   },
-  loginFirst: true,
-  setLoginFirst: isFirstLogin => set(() => ({ loginFirst: isFirstLogin })),
+  loginFirst: localStorage.getItem('loginFirst') === 'true',
+  setLoginFirst: isFirstLogin =>
+    set(() => {
+      localStorage.setItem('loginFirst', `${isFirstLogin}`);
+
+      return { loginFirst: isFirstLogin };
+    }),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
### 작업 개요

- 테이블 관리 화면 새로 고침 오류 수정

### 반영 브랜치

fix_manage-table_refresh -> dev

### 해결 과정(optional)

- 새로 고침 시 계속되는 first page의 등장과 table 탭으로 고정되는 문제 해결
- localStorage에 currentTab과 loginFirst 값을 저장해두어 문제를 해결

### 기타 참고 사항(optional)

- 추후 localStorage를 이용한 부분의 코드 분리가 필요하다.
