### PR TITLE
[Feat] 실시간 메뉴 관리 기능 구현

### DIFF
--- a/src/pages/Manage/RealTimeMenu/MenuCard.tsx
+++ b/src/pages/Manage/RealTimeMenu/MenuCard.tsx
@@ -1,37 +1,81 @@
 import { Label, NoImage } from '@/assets/icons';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MenuCardProps } from './MenuCard.types';
 import { labels } from '@/stores/labelData';
 
-export default function MenuCard({ menu }: MenuCardProps) {
-  const [selectLabel, setSelectLabel] = useState(Array(4).fill(false));
+export default function MenuCard({ menu, onSelectLabel }: MenuCardProps) {
+  const [selectLabel, setSelectLabel] = useState('');
+  const [isActive, setIsActive] = useState(true);
 
-  const handleSelectLabel = (idx: number) => {
-    setSelectLabel(prev => [
-      ...prev.map((isSelect, i) => {
-        return idx === i ? !isSelect : false;
-      }),
-    ]);
+  const handleSelectLabel = (id: string) => {
+    if (id === 'isActive') {
+      setIsActive(prev => !prev);
+      onSelectLabel(menu, '', !isActive);
+    } else {
+      setSelectLabel(prev => (prev === id ? '' : id));
+      onSelectLabel(menu, selectLabel === id ? '' : id, isActive);
+    }
   };
+  const handleInit = () => {
+    if (menu.hot) {
+      setSelectLabel('hot');
+    } else if (menu.new) {
+      setSelectLabel('new');
+    } else if (menu.soldOut) {
+      setSelectLabel('soldOut');
+    }
+
+    if (menu.isActive) {
+      setIsActive(true);
+    } else {
+      setIsActive(false);
+    }
+  };
+
+  useEffect(() => {
+    handleInit();
+  }, []);
 
   return (
     <div className="relative flex flex-col items-center gap-2 pr-7">
-      {!menu.image && <NoImage className="relative z-[2]" width={100} height={100} />}
+      {menu.image ? (
+        <img className="relative z-[2] h-24 w-24" src={menu.image} />
+      ) : (
+        <NoImage className="relative z-[2]" width={100} height={100} />
+      )}
       <div>{menu.title}</div>
       <div className="absolute right-4 top-0 z-[1]">
-        {labels.map(({ color }, i) => (
-          <div
-            className={clsx(selectLabel[i] ? 'translate-x-4' : 'hover:translate-x-4')}
-            onClick={() => handleSelectLabel(i)}
-          >
-            <Label
-              className={clsx(color, selectLabel[i] ? '' : 'opacity-50 hover:opacity-100')}
-              width={62}
-              height={20}
-            />
-          </div>
-        ))}
+        {labels.map(({ id, color }) => {
+          if (id === 'isActive') {
+            return (
+              <div
+                key={id}
+                className={clsx(isActive ? 'translate-x-4' : 'hover:translate-x-4')}
+                onClick={() => handleSelectLabel(id)}
+              >
+                <Label
+                  className={clsx(color, isActive ? '' : 'opacity-50')}
+                  width={62}
+                  height={20}
+                />
+              </div>
+            );
+          }
+          return (
+            <div
+              key={id}
+              className={clsx(selectLabel === id ? 'translate-x-4' : 'hover:translate-x-4')}
+              onClick={() => handleSelectLabel(id)}
+            >
+              <Label
+                className={clsx(color, selectLabel === id ? '' : 'opacity-50')}
+                width={62}
+                height={20}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/pages/Manage/RealTimeMenu/MenuCard.types.ts
+++ b/src/pages/Manage/RealTimeMenu/MenuCard.types.ts
@@ -2,4 +2,5 @@ import { Menu } from '@/stores/useMenuStore';
 
 export interface MenuCardProps {
   menu: Menu;
+  onSelectLabel: (menu: Menu, id: string, isActive: boolean) => void;
 }

--- a/src/pages/Manage/RealTimeMenuPage.tsx
+++ b/src/pages/Manage/RealTimeMenuPage.tsx
@@ -1,29 +1,51 @@
 import { Search } from '@/assets/icons';
 import Input from '@/components/common/Input/Input';
-import useMenuStore from '@/stores/useMenuStore';
-import { ChangeEvent, useState } from 'react';
+import useMenuStore, { Menu } from '@/stores/useMenuStore';
+import { ChangeEvent, useEffect, useState } from 'react';
 import MenuCard from './RealTimeMenu/MenuCard';
 import LabelCard from './RealTimeMenu/LabelCard';
 import { labels } from '@/stores/labelData';
+import { applyMenu, getMenu } from '@/apis/setting/menu.api';
 
 export default function RealTimeMenuPage() {
   const [search, setSearch] = useState('');
-  const { menus } = useMenuStore();
+  const { menus, setMenu } = useMenuStore();
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearch(e.target.value);
   };
-  const handleMenuSearch = () => {
-    // TODO 검색 로직 구현
+  const handleSelectLabel = (menu: Menu, id: string, isActive: boolean) => {
+    applyMenu(
+      {
+        categoryId: menu.category,
+        menuName: menu.title,
+        price: menu.price,
+        menuDetail: menu.description,
+        menuImg: menu.image ?? '',
+        origin: menu.origin,
+        isActive: isActive,
+        soldOut: id === 'soldOut',
+        hot: id === 'hot',
+        new: id === 'new',
+        isRunningOut: false,
+      },
+      menu.id
+    );
   };
+
+  useEffect(() => {
+    getMenu().then(menuData => {
+      setMenu(menuData);
+    });
+  }, []);
 
   return (
     <div className="relative flex h-full flex-col gap-5 p-10">
       <div className="flex w-full flex-col items-center rounded-lg border border-d50">
         <div className="py-3 text-2xl font-bold">라벨</div>
         <div className="flex gap-4 py-4">
-          {labels.map(({ title, color }) => (
-            <LabelCard title={title} labelColor={color} />
+          {labels.map(({ id, title, color }) => (
+            <LabelCard key={id} title={title} labelColor={color} />
           ))}
         </div>
       </div>
@@ -33,10 +55,9 @@ export default function RealTimeMenuPage() {
           <Input
             id="search"
             type="text"
-            placeholder="메뉴이름 혹은 카테고리 검색"
+            placeholder="메뉴 이름 검색"
             value={search}
             handleInputChange={handleInputChange}
-            onClickIcon={handleMenuSearch}
           >
             <Search width="16" height="16" className="stroke-d50" />
           </Input>
@@ -44,7 +65,7 @@ export default function RealTimeMenuPage() {
         <div className="flex flex-wrap gap-14">
           {menus.map(menu => (
             <MenuCard menu={menu} />
-          ))}
+            ))}
         </div>
       </div>
     </div>

--- a/src/pages/Manage/RealTimeMenuPage.tsx
+++ b/src/pages/Manage/RealTimeMenuPage.tsx
@@ -63,8 +63,17 @@ export default function RealTimeMenuPage() {
           </Input>
         </div>
         <div className="flex flex-wrap gap-14">
-          {menus.map(menu => (
-            <MenuCard menu={menu} />
+          {menus
+            // 메뉴 검색 필터링
+            .filter(({ title, category }) => {
+              if (search === '') {
+                return true;
+              } else {
+                return title.includes(search) || category.includes(search);
+              }
+            })
+            .map(menu => (
+              <MenuCard key={menu.id} menu={menu} onSelectLabel={handleSelectLabel} />
             ))}
         </div>
       </div>

--- a/src/stores/labelData.ts
+++ b/src/stores/labelData.ts
@@ -1,6 +1,6 @@
 export const labels = [
-  { title: '품절', color: 'text-d200' },
-  { title: 'Hot', color: 'text-highlightRed' },
-  { title: 'New', color: 'text-highlightYellow' },
-  { title: 'on/off', color: 'text-black' },
+  { id: 'soldOut', title: '품절', color: 'text-d200' },
+  { id: 'hot', title: 'Hot', color: 'text-highlightRed' },
+  { id: 'new', title: 'New', color: 'text-highlightYellow' },
+  { id: 'isActive', title: 'on/off', color: 'text-black' },
 ];

--- a/src/stores/useMenuStore.ts
+++ b/src/stores/useMenuStore.ts
@@ -21,6 +21,11 @@ export type Menu = {
   origin: string;
   image?: string;
   addOptions?: AddOption[] | null;
+  isActive?: boolean;
+  soldOut?: boolean;
+  hot?: boolean;
+  new?: boolean;
+  isRunningOut?: boolean;
 };
 
 type MenuState = {
@@ -77,6 +82,10 @@ const useMenuStore = create<MenuState>(set => ({
         price: item.price,
         image: item.menuImg,
         origin: item.origin || '',
+        isActive: !!item.isActive,
+        hot: !!item.hot,
+        new: !!item.new,
+        soldOut: !!item.soldOut,
         addOptions:
           item.options?.map(option => ({
             id: option.id as string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,6 +151,10 @@ export type SetMenuData = {
   origin: string | null;
   options?: SetOptionsData[];
   isActive?: boolean;
+  soldOut?: boolean;
+  hot?: boolean;
+  new?: boolean;
+  isRunningOut?: boolean;
 };
 
 export type SetOptionsData = {


### PR DESCRIPTION
### 작업 개요

- 실시간 메뉴 관리 기능 구현
- 검색 기능 구현

### 반영 브랜치

feat_real-time-menu_api -> dev

### 연관된 이슈(optional)

- #9 

### 스크린샷(optional)

- 실시간 메뉴 관리 화면
![image](https://github.com/user-attachments/assets/2e5ab18a-8ca2-455f-8e15-462cd60c6091)
- 적용 화면
![image](https://github.com/user-attachments/assets/ed0d1d56-76f9-4bad-8068-38857e94e4d3)

### 기타 참고 사항(optional)

- 코드가 상당히 더럽습니다...

### 체크리스트

- [x] 메뉴 관리 라벨이 소비자 화면에 적용되는가?
